### PR TITLE
guard for weird hands

### DIFF
--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -1,52 +1,56 @@
 function level_up_hand_chips(card, hand, instant, amount)
-    amount = amount or 1
-    G.GAME.hands[hand].level = math.max(0, G.GAME.hands[hand].level + amount)
+    if (G.GAME.hands[hand].level and G.GAME.hands[hand].chips) then
+        amount = amount or 1
+        G.GAME.hands[hand].level = math.max(0, G.GAME.hands[hand].level + amount)
 
-    G.GAME.hands[hand].chips = math.max(0, G.GAME.hands[hand].chips + (G.GAME.hands[hand].l_chips * amount * 2))
-    if not instant then 
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
-            play_sound('tarot1')
-            if card then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = true
-            return true end }))
-        update_hand_text({delay = 0}, {chips = G.GAME.hands[hand].chips, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('tarot1')
-            if card then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = nil
-            return true end }))
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
-        delay(1.3)
+        G.GAME.hands[hand].chips = math.max(0, G.GAME.hands[hand].chips + (G.GAME.hands[hand].l_chips * amount * 2))
+        if not instant then 
+            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
+                play_sound('tarot1')
+                if card then card:juice_up(0.8, 0.5) end
+                G.TAROT_INTERRUPT_PULSE = true
+                return true end }))
+            update_hand_text({delay = 0}, {chips = G.GAME.hands[hand].chips, StatusText = true})
+            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
+                play_sound('tarot1')
+                if card then card:juice_up(0.8, 0.5) end
+                G.TAROT_INTERRUPT_PULSE = nil
+                return true end }))
+            update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
+            delay(1.3)
+        end
+        G.E_MANAGER:add_event(Event({
+            trigger = 'immediate',
+            func = (function() check_for_unlock{type = 'upgrade_hand', hand = hand, level = G.GAME.hands[hand].level} return true end)
+        }))
     end
-    G.E_MANAGER:add_event(Event({
-        trigger = 'immediate',
-        func = (function() check_for_unlock{type = 'upgrade_hand', hand = hand, level = G.GAME.hands[hand].level} return true end)
-    }))
 end
 
 function level_up_hand_mult(card, hand, instant, amount)
-    amount = amount or 1
-    G.GAME.hands[hand].level = math.max(0, G.GAME.hands[hand].level + amount)
+    if (G.GAME.hands[hand].level and G.GAME.hands[hand].mult) then
+        amount = amount or 1
+        G.GAME.hands[hand].level = math.max(0, G.GAME.hands[hand].level + amount)
 
-    G.GAME.hands[hand].mult = math.max(1, G.GAME.hands[hand].mult + (G.GAME.hands[hand].l_mult * amount * 2))
-    if not instant then 
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
-            play_sound('tarot1')
-            if card then card:juice_up(0.8, 0.5) end
-            G.TAROT_INTERRUPT_PULSE = true
-            return true end }))
-        update_hand_text({delay = 0}, {mult = G.GAME.hands[hand].mult, StatusText = true})
-        G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
-            play_sound('tarot1')
-            if card then card:juice_up(0.8, 0.5) end
-            return true end }))
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
-        delay(1.3)
+        G.GAME.hands[hand].mult = math.max(1, G.GAME.hands[hand].mult + (G.GAME.hands[hand].l_mult * amount * 2))
+        if not instant then 
+            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.2, func = function()
+                play_sound('tarot1')
+                if card then card:juice_up(0.8, 0.5) end
+                G.TAROT_INTERRUPT_PULSE = true
+                return true end }))
+            update_hand_text({delay = 0}, {mult = G.GAME.hands[hand].mult, StatusText = true})
+            G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
+                play_sound('tarot1')
+                if card then card:juice_up(0.8, 0.5) end
+                return true end }))
+            update_hand_text({sound = 'button', volume = 0.7, pitch = 0.9, delay = 0}, {level=G.GAME.hands[hand].level})
+            delay(1.3)
+        end
+        G.E_MANAGER:add_event(Event({
+            trigger = 'immediate',
+            func = (function() check_for_unlock{type = 'upgrade_hand', hand = hand, level = G.GAME.hands[hand].level} return true end)
+        }))
     end
-    G.E_MANAGER:add_event(Event({
-        trigger = 'immediate',
-        func = (function() check_for_unlock{type = 'upgrade_hand', hand = hand, level = G.GAME.hands[hand].level} return true end)
-    }))
 end
 
 function redeemed_voucher_count()


### PR DESCRIPTION
should fix this crash:

```
INFO - [G] 2025-05-06 21:10:44 :: ERROR :: StackTrace :: Oops! The game crashed
[SMODS allinjest "Utils/functions.lua"]:31: attempt to perform arithmetic on field 'mult' (a nil value)
Stack Traceback
===============
(1) Lua local 'handler' at file 'main.lua:612'
	Local variables:
	 msg = string: "[SMODS allinjest \"Utils/functions.lua\"]:31: attempt to perform arithmetic on field 'mult' (a nil value)"
	 (*temporary) = Lua function '?' (defined at line 31 of chunk [SMODS _ "src/logging.lua"])
	 (*temporary) = number: 2.39547e-314
	 (*temporary) = string: "Oops! The game crashed\
"
(2) LÖVE metamethod at file 'boot.lua:352'
	Local variables:
	 errhand = Lua function '?' (defined at line 598 of chunk main.lua)
	 handler = Lua function '?' (defined at line 598 of chunk main.lua)
(3) Lua global 'level_up_hand_mult' at file 'Utils/functions.lua:31' (from mod with id allinjest)
	Local variables:
	 card = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 hand = string: "Wzon_Obliterate"
	 instant = boolean: true
	 amount = number: 1
	 (*temporary) = table: 0x031c5442e0  {order:1, l_mult:0, l_chips:0, visible:false, played_this_round:0, example:table: 0x031c5d0110, level:2, _saved_d_u:true, played:0}
	 (*temporary) = C function: builtin#61
	 (*temporary) = number: 6.61732e-314
	 (*temporary) = number: 1
	 (*temporary) = nil
	 (*temporary) = number: 0
	 (*temporary) = table: 0x0125a1a0c8  {1:table: 0x031e3c73f0, 2:table: 0x016fff7ca0, 3:table: 0x031e2fd9b8, 4:table: 0x031e2fdbe8, 5:table: 0x04101d7828, 6:table: 0x031d262d00, 7:table: 0x031e578f78 (more...)}
	 (*temporary) = string: "attempt to perform arithmetic on field 'mult' (a nil value)"
(4) Lua method 'use' at file 'Items/Consumables/pulsar.lua:44' (from mod with id allinjest)
	Local variables:
	 self = table: 0x0126ece040  {order:119, config:table: 0x031ccd86e8, cost:4, unlocked:true, soul_set:Planet, discovered:true, hidden:true, soul_rate:0.003, set:Spectral, pos:table: 0x031ccd8668 (more...)}
	 card = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 area = nil
	 copier = nil
	 (for generator) = C function: next
	 (for state) = table: 0x0410586640  {paperback_Spectrum Five:table: 0x03fe543ef8, paperback_Straight Spectrum:table: 0x031eaec540, garb_blush:table: 0x031e7c03b8, garb_caliginous:table: 0x031d808180 (more...)}
	 (for control) = userdata: NULL
	 hand_key = string: "Wzon_Obliterate"
	 hand_data = table: 0x031c5442e0  {order:1, l_mult:0, l_chips:0, visible:false, played_this_round:0, example:table: 0x031c5d0110, level:2, _saved_d_u:true, played:0}
(5) Lua upvalue 'old_Card_use_consumable' at file 'card.lua:1747'
	Local variables:
	 self = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 area = nil
	 copier = nil
	 joker = nil
	 used_tarot = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 obj = table: 0x0126ece040  {order:119, config:table: 0x031ccd86e8, cost:4, unlocked:true, soul_set:Planet, discovered:true, hidden:true, soul_rate:0.003, set:Spectral, pos:table: 0x031ccd8668 (more...)}
(6) Lua upvalue 'Card_use_consumeable_ref' at file 'CardSleeves.lua:2027' (from mod with id CardSleeves)
	Local variables:
	 self = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 sleeve_center = table: 0x0125cf8830  {order:11, unlocked:true, _u:false, _saved_d_u:true, prefix_config:table: 0x0125ac9b98, pos:table: 0x0125dc33f0, loc_vars:function: 0x0125b52520 (more...)}
(7) Lua upvalue 'use_consumeable_old' at file 'Betmma_Vouchers.lua:5340' (from mod with id BetmmaVouchers)
	Local variables:
	 self = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 area = nil
	 copier = nil
(8) Lua method 'use_consumeable' at file 'garbpack.lua:66' (from mod with id GARBPACK)
	Local variables:
	 self = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 area = table: 0x042ba7abc8  {config:table: 0x042ba7ab80, shuffle_amt:0, VT:table: 0x042ba7b638, card_w:2.0487804878049, offset:table: 0x042ba7bbb0, STATIONARY:true, under_overlay:false (more...)}
	 copier = nil
(9) Lua upvalue 'G_FUNCS_use_card_ref' at file 'functions/button_callbacks.lua:2353'
	Local variables:
	 e = table: 0x042d8e2540  {config:table: 0x042d8e0398, created_on_pause:false, UIT:4, VT:table: 0x042d8e6610, offset:table: 0x042d8e6bf0, STATIONARY:false, under_overlay:false (more...)}
	 mute = nil
	 nosave = nil
	 card = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 area = table: 0x042ba7abc8  {config:table: 0x042ba7ab80, shuffle_amt:0, VT:table: 0x042ba7b638, card_w:2.0487804878049, offset:table: 0x042ba7bbb0, STATIONARY:true, under_overlay:false (more...)}
	 prev_state = number: 999
	 dont_dissolve = nil
	 delay_fac = number: 1
	 is_pack_card = boolean: true
	 is_alchemy_pack_card = boolean: false
	 nc = nil
	 select_to = nil
	 is_cine = boolean: false
(10) Lua upvalue 'use_cardref' at file 'Betmma_Vouchers.lua:1152' (from mod with id BetmmaVouchers)
	Local variables:
	 e = table: 0x042d8e2540  {config:table: 0x042d8e0398, created_on_pause:false, UIT:4, VT:table: 0x042d8e6610, offset:table: 0x042d8e6bf0, STATIONARY:false, under_overlay:false (more...)}
	 mute = nil
	 nosave = nil
	 card = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
(11) Lua upvalue 'use_card_ref' at file 'indiv_jokers/fairy_festival.lua:89' (from mod with id LobotomyCorp)
	Local variables:
	 e = table: 0x042d8e2540  {config:table: 0x042d8e0398, created_on_pause:false, UIT:4, VT:table: 0x042d8e6610, offset:table: 0x042d8e6bf0, STATIONARY:false, under_overlay:false (more...)}
	 mute = nil
	 nosave = nil
	 card = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
(12) Lua function '?' at file 'data/main.lua:1995' (from mod with id Reverie) (best guess)
	Local variables:
	 e = table: 0x042d8e2540  {config:table: 0x042d8e0398, created_on_pause:false, UIT:4, VT:table: 0x042d8e6610, offset:table: 0x042d8e6bf0, STATIONARY:false, under_overlay:false (more...)}
	 card = table: 0x041c52f618  {grim_retrigger:0, bypass_discovery_center:true, config:table: 0x041c9a4430, created_on_pause:false, from_area:table: 0x042ba7abc8, facing:front (more...)}
	 is_consumeable = table: 0x031ccd86e8  {moon:true}
(13) Lua upvalue 'UIElementClickRef' at file 'engine/ui.lua:1019'
	Local variables:
	 self = table: 0x042d8e2540  {config:table: 0x042d8e0398, created_on_pause:false, UIT:4, VT:table: 0x042d8e6610, offset:table: 0x042d8e6bf0, STATIONARY:false, under_overlay:false (more...)}
(14) Lua method 'click' at file 'Items/Jokers.lua:2439' (from mod with id showdown)
	Local variables:
	 self = table: 0x042d8e2540  {config:table: 0x042d8e0398, created_on_pause:false, UIT:4, VT:table: 0x042d8e6610, offset:table: 0x042d8e6bf0, STATIONARY:false, under_overlay:false (more...)}
(15) Lua method 'update' at file 'engine/controller.lua:375'
	Local variables:
	 self = table: 0x0126f87cc0  {clicked:table: 0x0126f87d08, focused:table: 0x0126f87d88, dragging:table: 0x0126f87e08, released_on:table: 0x0126f87f38, overlay_timer:0, cursor_down:table: 0x0126f87e88 (more...)}
	 dt = number: 0.0500681
(16) Lua upvalue 'gameUpdateRef' at file 'game.lua:3554'
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(17) Lua upvalue 'upd' at Steamodded file 'src/ui.lua:86'
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(18) Lua upvalue 'game_updateref' at file 'Grim.lua:4251' (from mod with id GRM)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(19) Lua upvalue 'game_updateref' at file 'LobotomyCorp.lua:1910' (from mod with id LobotomyCorp)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(20) Lua upvalue 'game_updateref' at file 'other/colours.lua:1540' (from mod with id MoreFluff)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(21) Lua upvalue 'update_ref' at file 'MoreFluff.lua:1061' (from mod with id MoreFluff)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(22) Lua upvalue 'updateRef' at file 'hooks/game.lua:100' (from mod with id victinscollection)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(23) Lua upvalue 'gm_u' at file 'Items/Jokers.lua:2346' (from mod with id showdown)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(24) Lua method 'update' at file 'src/startup/game_hooks.lua:54' (from mod with id mistigris)
	Local variables:
	 self = table: 0x0124637848  {TILESCALE:4.0909090909091, P_BLINDS:table: 0x016ffe14f8, F_GUIDE:false, TILE_W:20, TILE_H:11.5, ROOM_ATTACH:table: 0x04102ad228, FRAMES:table: 0x012469c800 (more...)}
	 dt = number: 0.0500681
(25) Lua upvalue 'love_update_ref' at file 'main.lua:1022'
	Local variables:
	 dt = number: 0.0500681
(26) Lua field 'update' at file 'main.lua:4261'
	Local variables:
	 dt = number: 0.0500681
(27) Lua function '?' at file 'main.lua:943' (best guess)
(28) global C function 'xpcall'
(29) LÖVE function at file 'boot.lua:377' (best guess)
	Local variables:
	 func = Lua function '?' (defined at line 911 of chunk main.lua)
	 inerror = boolean: true
	 deferErrhand = Lua function '(LÖVE Function)' (defined at line 348 of chunk [love "boot.lua"])
	 earlyinit = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])

INFO - [G] line not found
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] 2025-05-06 21:10:44 :: INFO  :: StackTrace :: Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-0506a-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.7.1
Platform: OS X
Steamodded Mods:
    1: More Fluff by notmario, CHECK CREDITS IN MOD TAB [ID: MoreFluff, Version: 1.5.1, Uses Lovely]
    2: Balatro Hevven by TheAlternateDoctor, missingnumber, NoahAmp [ID: BHevven, Priority: 1000, Version: 1.0, Uses Lovely]
    3: Rift-Raft by vitellary [ID: RiftRaft, Priority: 115, Version: 1.0.0, Uses Lovely]
    4: Showdown by Mistyk__ [ID: showdown, Priority: 5, Version: 1.3, Uses Lovely]
    5: Cartomancer by stupxd aka stupid [ID: cartomancer, Priority: 69, Version: 4.13-hotfix, Uses Lovely]
    6: SoulEverything by OppositeWolf770 [ID: SoulEverything, Version: 1.2.0]
    7: rcBalatro by realicraft [ID: rcbalatro, Priority: 126, Version: 0.2.2]
    8: Balatro+ by SomeCoder99 [ID: balatro_plus, Version: 1.0.2-a, Uses Lovely]
    9: UnStable by Kirbio, RamChops Games [ID: UnStable, Priority: 777, Version: 1.2b, Uses Lovely]
    10: UnStableEX by Kirbio [ID: UnStableEX, Priority: 99999, Version: 0.2.2e]
    11: Plantain by TeamToaster [ID: plantain, Priority: 1, Version: 1.0.0, Uses Lovely]
    12: KCVanilla by krackocloud [ID: kcvanilla, Version: 2.4.1, Uses Lovely]
    13: Blueprint by stupxd aka stupid, Jonathan [ID: blueprint, Priority: 69, Version: 3.3, Uses Lovely]
    14: Warp Zone! by Freh [ID: Wzone, Uses Lovely]
    15: Lobotomy Corporation by Mysthaps [ID: LobotomyCorp, Version: 1.2.0c, Uses Lovely]
    16: Next Ante Preview by DigitalDetective47 [ID: AntePreview, Priority: -1000000, Version: 3.0.1, Uses Lovely]
    17: Bird Jokers by Justin [ID: BirdJokers, Uses Lovely]
    18: Too Many Jokers by cg [ID: toomanyjokers, Priority: 1000000, Uses Lovely]
    19: Neato Jokers by Neato [ID: Neato_Jokers, Version: 1.1.6]
    20: Mistigris by astrapboy [ID: mistigris, Priority: 69, Version: 0.5.0-dev_25w14b, Uses Lovely]
    21: Balatro Goes Kino by IcyEthics [ID: kino, Version: 0.9.0a, Uses Lovely]
    22: Galdur by Eremel_ [ID: galdur, Priority: -10000, Version: 1.2, Uses Lovely]
    23: Fusion Jokers by itayfeder, Lyman [ID: FusionJokers, Priority: -10000]
    24: Redux Arcanum by itayfeder, Lyman, Jumbo [ID: ReduxArcanum, Version: 2.0.0~PreRelease5, Uses Lovely]
    25: Lucky Jimbos: Joker Pack by LuckySix [ID: L6_luckyjimbo, Version: 0.3~alpha-5]
    26: Card Sleeves by Larswijn [ID: CardSleeves, Priority: -10, Version: 1.7.5, Uses Lovely]
    27: TIWMIG by Oinite [ID: tiwmig, Version: 0.1.0, Uses Lovely]
    28: sortatro by nnmrts [ID: sortatro, Version: 0.1.0]
    29: Handsome Devils by Kars, sup3p [ID: HandsomeDevils, Version: 1.0.0, Uses Lovely]
    30: Stuffz by Mini [ID: Stuffz, Version: 1.1.1]
    31: Custom Suit Order by DigitalDetective47 [ID: SuitOrder, Priority: 1.79e+308, Version: 1.0.2]
    32: Sarcpot by SarcasticPotato [ID: sarcpot, Version: 0.1.10, Uses Lovely]
    33: JankJonklersMod by Lyman [ID: JankJonklersMod]
    34: Reverie by DVRP [ID: Reverie, Priority: 1, Version: 1.5.3b, Uses Lovely]
    35: 5 legendary challenges by Betmma [ID: legendaryChallenges]
    36: Malverk by Eremel_ [ID: malverk, Priority: -999999, Version: 1.1.3a, Uses Lovely]
    37: Tsu's Jeopardy by tje.tsu [ID: TsusJeo, Version: 0.25 [TEST RELEASE]]
    38: Paperback by PaperMoon, OppositeWolf770, srockw, Nether, B [ID: paperback, Version: 0.6.4b, Uses Lovely]
    39: Grim by mathguy [ID: GRM, Version: 1.2.6d, Uses Lovely]
    40: Betmma Vouchers by Betmma [ID: BetmmaVouchers, Priority: -1, Version: 3.0.2.2(20250504)]
    41: Betmma Voucher Pack by Betmma, nicholassam6425 [ID: BetmmaVoucherPack]
    42: Handy by SleepyG11 [ID: Handy, Version: 1.4.2a, Uses Lovely]
    43: Severed by frogzsj [ID: svrd, Priority: 13, Version: 0.1, Uses Lovely]
    44: rcBLib by realicraft [ID: rcblib, Priority: 120, Version: 1.1.0, Uses Lovely]
    45: Reverse Tarot + Hijinks by SkywawrdTARDIS [ID: reverse_tarot, Version: 1.5.5, Uses Lovely]
    46: Victin's Collection by Victin [ID: victinscollection, Uses Lovely]
    47: Bakery by BakersDozenBagels [ID: Bakery, Version: 2.7.3, Uses Lovely]
    48: 3x Credits by AuroraAquir [ID: 3xCredits, Priority: -33, Version: 1.0.0, Uses Lovely]
    49: Mossed by Larantula, Jetziel [ID: mossed, Priority: -20, Version: 1.0.0]
    50: Betmma Jokers by Betmma [ID: BetmmaJokers]
    51: TOGA's Stuff by TheOneGoofAli [ID: TOGAPack, Priority: 2, Version: 1.4.0, Uses Lovely]
    52: Familiar by RattlingSnow353, humplydinkle [ID: familiar, Priority: 1, Version: 0.2.0, Uses Lovely]
    53: Seven Deadly Decks by AstroLightz [ID: 7DeadlyDecks, Priority: -5, Version: 1.1.0]
    54: Garbshit by garb [ID: GARBPACK, Version: 2.0.1, Uses Lovely]
    55: SDM_0's Stuff by SDM_0 [ID: sdm0sstuff, Version: 1.6.4o, Uses Lovely]
    56: Cosmos by Cosmos [ID: Cosmos, Version: 0.0.3, Uses Lovely]
    57: Snows Mods by RattlingSnow353 [ID: SnowMods, Version: 0.2.0]
    58: Joker Evolution by SDM_0 [ID: joker_evolution, Priority: -1000, Version: 1.2.3c, Uses Lovely]
    59: Better Vouchers This Run UI by Betmma [ID: BetterVouchersThisRunUI]
    60: Buffoonery by PinkMaggit [ID: Buffoonery, Version: 1.2.1, Uses Lovely]
    61: Banner by SylviBlossom [ID: banner, Version: 1.1.1, Uses Lovely]
    62: ExtraCredit by CampfireCollective [ID: extracredit, Priority: 1, Version: 1.3.0, Uses Lovely]
    63: JokerSellValue by OppositeWolf770 [ID: JokerSellValue, Priority: 100000, Version: 1.2.1]
    64: JokerDisplay by nh6574 [ID: JokerDisplay, Priority: -100000, Version: 1.8.4.1]
    65: FickleFox by FoxDeploy [ID: fickleFox, Priority: 1, Version: 0.0.4, Uses Lovely]
    66: Revo's Vault by CodeRevo [ID: RevosVault, Version: 4.2.0d, Uses Lovely]
    67: All in Jest by Nevernamed, survivalaiden, RattlingSnow353 [ID: allinjest, Priority: 9999, Version: 0.2.2]
    68: Jank Challenges by Lyman [ID: JankChallenges]
    69: Celeste Card Collection by AuroraAquir, toneblock, Gappie, bein, sunsetquasar, goose! [ID: CelesteCardCollection, Priority: 10, Version: 0.37.4, Uses Lovely]
    70: Lucky Rabbit by Fennex, Trif, HarmoniousJoker [ID: LuckyRabbit, Version: 1.0.0, Uses Lovely]
    71: Unjankify by Blazingulag [ID: Unjank, Version: 1.0.0, Uses Lovely]
    72: Prism by Blazingulag [ID: Prism, Version: 1.9.0-ALPHA, Uses Lovely]
Lovely Mods:
```