### PR TITLE
Various Fixes to Stultor

### DIFF
--- a/Items/Jokers/stultor.lua
+++ b/Items/Jokers/stultor.lua
@@ -38,12 +38,10 @@ local stultor = {
 local ease_anteref = ease_ante
 function ease_ante(mod)
     if mod ~= 0 then
-        local has_stultor = next(SMODS.find_card("j_aij_stultor"))
-        if has_stultor then
-            for i = 1, has_stultor do
-                G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + SMODS.find_card("j_aij_stultor")[i].ability.extra.free_rerolls
-            end
-        end
+        local sultors = SMODS.find_card("j_aij_stultor")
+            for i = 1, #sultors do
+                G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + sultors[i].ability.extra.free_rerolls
+                    end
     end
     
     local ref = ease_anteref(mod)

--- a/Items/Jokers/stultor.lua
+++ b/Items/Jokers/stultor.lua
@@ -38,6 +38,7 @@ local stultor = {
 local ease_anteref = ease_ante
 function ease_ante(mod)
     if mod ~= 0 then
+G.GAME.jest_free_stultor_rerolls = 0
         local sultors = SMODS.find_card("j_aij_stultor")
             for i = 1, #sultors do
                 G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + sultors[i].ability.extra.free_rerolls

--- a/Items/Jokers/stultor.lua
+++ b/Items/Jokers/stultor.lua
@@ -29,7 +29,10 @@ local stultor = {
       
     end,
     add_to_deck = function(self, card, from_debuff)
-        G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + 1
+        G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + card.ability.extra.free_rerolls
+    end,
+    remove_from_deck = function(self, card, from_debuff)
+        G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls - card.ability.extra.free_rerolls
     end,
 }
 local ease_anteref = ease_ante

--- a/Items/Jokers/stultor.lua
+++ b/Items/Jokers/stultor.lua
@@ -29,7 +29,35 @@ local stultor = {
       
     end,
     add_to_deck = function(self, card, from_debuff)
+        local orig_value = G.GAME.jest_free_stultor_rerolls
         G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + card.ability.extra.free_rerolls
+        if orig_value <= 0 and G.GAME.jest_free_stultor_rerolls > 0 and G.STATE == G.STATES.BLIND_SELECT then
+            
+            -- This quickly removed the original blind_prompt area (where the reroll button goes)
+            -- And replaces it with a new one
+            G.E_MANAGER:add_event(Event({
+                trigger = 'immediate',
+                func = (function()
+                    if G.blind_prompt_box then
+                        G.blind_prompt_box:remove()
+                    end
+                    G.blind_prompt_box = UIBox{
+                        definition = {n=G.UIT.ROOT, config = {align = 'cm', colour = G.C.CLEAR, padding = 0.2}, nodes={
+                            {n=G.UIT.R, config={align = "cm"}, nodes={
+                                {n=G.UIT.O, config={object = DynaText({string = localize('ph_choose_blind_1'), colours = {G.C.WHITE}, shadow = true, bump = true, scale = 0.6, maxw = 5}), id = 'prompt_dynatext1'}}
+                            }},
+                            {n=G.UIT.R, config={align = "cm"}, nodes={
+                                {n=G.UIT.O, config={object = DynaText({string = localize('ph_choose_blind_2'), colours = {G.C.WHITE}, shadow = true, bump = true, scale = 0.7, maxw = 5, silent = true}), id = 'prompt_dynatext2'}}
+                            }},
+                            UIBox_button({label = {localize('b_reroll_boss'), localize('$')..'0'}, button = "jest_free_reroll_boss", func = 'jest_free_reroll_boss_button'})
+                        }},
+                        config = {align="cm", offset = {x=0,y=0},major = G.HUD:get_UIE_by_ID('row_blind'), bond = 'Weak'}
+                    }
+                    return true
+                end)
+            }))
+                
+        end
     end,
     remove_from_deck = function(self, card, from_debuff)
         G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls - card.ability.extra.free_rerolls
@@ -38,11 +66,11 @@ local stultor = {
 local ease_anteref = ease_ante
 function ease_ante(mod)
     if mod ~= 0 then
-G.GAME.jest_free_stultor_rerolls = 0
+        G.GAME.jest_free_stultor_rerolls = 0
         local sultors = SMODS.find_card("j_aij_stultor")
-            for i = 1, #sultors do
-                G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + sultors[i].ability.extra.free_rerolls
-                    end
+        for i = 1, #sultors do
+            G.GAME.jest_free_stultor_rerolls = G.GAME.jest_free_stultor_rerolls + sultors[i].ability.extra.free_rerolls
+        end
     end
     
     local ref = ease_anteref(mod)


### PR DESCRIPTION
This PR was prompted by an [Issue submitted to Bunco](https://github.com/jumbocarrot0/Bunco/issues/32) showing Stultor acting weirdly when debuffed. I then encountered a couple other bugs. So in total this PR:
- Fixes a bug where Stultor would add another reroll when getting undebuffed (by removing a reroll upon getting debuffed)
- Fixes a bug where Stultor's free reroll would persist after being sold/destroyed (fixed same as above)
- The "reroll boss" button will now appear if Stultor is added mid blind selection (e.g. via Judgement)
- Free rerolls are now added based on Stultor's stats (important for dongtong) and should better work when there are multiple Stultors (before it only considered the stats of the first Stultor in joker order, not all of them)