### PR TITLE
Fix for reloading save with Clay Joker or Visage

### DIFF
--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -4,9 +4,9 @@ local clay_joker = {
 
     key = "clay_joker",
     config = {
-      extra = {
+        extra = {
 
-      }
+        }
     },
     rarity = 2,
     pos = { x = 22, y = 3 },
@@ -16,32 +16,34 @@ local clay_joker = {
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
-  
+
     loc_vars = function(self, info_queue, card)
-        if G.GAME.jest_clay_last_destroyed then  
-            info_queue[#info_queue + 1] = G.P_CENTERS[G.GAME.jest_clay_last_destroyed.config.center.key] 
+        if G.jest_clay_last_destroyed.cards[1] then
+            local other_joker = G.jest_clay_last_destroyed.cards[1]
+            info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
         end
-        return { vars = {  } }
+        return { vars = {} }
     end,
-  
+
     calculate = function(self, card, context)
-        local other_joker = G.GAME.jest_clay_last_destroyed
-		return SMODS.blueprint_effect(card, other_joker, context)
+        local other_joker = G.jest_clay_last_destroyed.cards[1]
+        return SMODS.blueprint_effect(card, other_joker, context)
     end
-  
+
 }
 local start_dissolve_ref = Card.start_dissolve
 function Card:start_dissolve(dissolve_colours, silent, dissolve_time_fac, no_juice)
-  local ref = start_dissolve_ref(self, dissolve_colours, silent, dissolve_time_fac, no_juice)
-  if G.jokers and self.ability.set == 'Joker' then
-    if not self.ability.jest_sold_self then
-      if self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker' then
-        G.GAME.jest_clay_last_destroyed = nil
-      else
-        G.GAME.jest_clay_last_destroyed = self
-      end
+    local ref = start_dissolve_ref(self, dissolve_colours, silent, dissolve_time_fac, no_juice)
+    if G.jokers and self.ability.set == 'Joker' then
+        if not self.ability.jest_sold_self then
+            G.jest_clay_last_destroyed.cards = {}
+            if not (self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker') then
+                local copied_card = copy_card(self, nil, 0) -- Creates a copy with 0 scale
+                G.jest_clay_last_destroyed:emplace(copied_card)
+            end
+        end
     end
-  end
-  return ref
+    return ref
 end
-return { name = {"Jokers"}, items = {clay_joker} }
+
+return { name = { "Jokers" }, items = { clay_joker } }

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -4,42 +4,44 @@ local visage = {
 
     key = "visage",
     config = {
-      extra = {
+        extra = {
 
-      }
+        }
     },
     rarity = 2,
-    pos = { x = 21, y = 8},
+    pos = { x = 21, y = 8 },
     atlas = 'joker_atlas',
     cost = 8,
     unlocked = true,
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
-  
+
     loc_vars = function(self, info_queue, card)
-        if G.GAME.jest_visage_last_sold then  
-            info_queue[#info_queue + 1] = G.P_CENTERS[G.GAME.jest_visage_last_sold.config.center.key] 
+        if G.jest_visage_last_sold.cards[1] then
+            local other_joker = G.jest_visage_last_sold.cards[1]
+            info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
         end
-        return { vars = {  } }
+        return { vars = {} }
     end,
-  
+
     calculate = function(self, card, context)
-        local other_joker = G.GAME.jest_visage_last_sold
-		return SMODS.blueprint_effect(card, other_joker, context)
+        local other_joker = G.jest_visage_last_sold.cards[1]
+        return SMODS.blueprint_effect(card, other_joker, context)
     end
-  
+
 }
 local sell_card_ref = Card.sell_card
 function Card:sell_card()
-  local ref = sell_card_ref(self)
-  if G.jokers and self.ability.set == 'Joker' then
-    if self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker' then
-        G.GAME.jest_visage_last_sold = nil
-    else
-        G.GAME.jest_visage_last_sold = self
+    local ref = sell_card_ref(self)
+    if G.jokers and self.ability.set == 'Joker' then
+        G.jest_visage_last_sold.cards = {}
+        if not (self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker') then
+            local copied_card = copy_card(self, nil, 0) -- Creates a copy with 0 scale
+            G.jest_visage_last_sold:emplace(copied_card)
+        end
     end
-  end
-  return ref
+    return ref
 end
-return { name = {"Jokers"}, items = {visage} }
+
+return { name = { "Jokers" }, items = { visage } }

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -25,9 +25,9 @@ payload = '''
 if self.ability.name == 'j_aij_clay_joker' or self.ability.name == 'j_aij_visage' then
 	local other_joker = nil
     if self.ability.name == 'j_aij_visage' then
-        other_joker = G.GAME.jest_visage_last_sold
+        other_joker = G.jest_visage_last_sold.cards[1]
     elseif self.ability.name == 'j_aij_clay_joker' then
-        other_joker = G.GAME.jest_clay_last_destroyed
+        other_joker = G.jest_clay_last_destroyed.cards[1]
     end
     if other_joker and other_joker ~= self and other_joker.config.center.blueprint_compat then
         self.ability.blueprint_compat = 'compatible'
@@ -1344,4 +1344,23 @@ line_prepend = "$indent"
 payload = '''
 
 next(SMODS.find_card('j_aij_touchstone')) and AllInJest.touchstone_deck_preview() or nil,
+'''
+
+# Add CardAreas used to store the jokers that Clay Joker and Visage will copy
+# Using CardAreas so that reloading a run works properly
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "self.discard = CardArea("
+position = "before"
+match_indent = true
+payload = '''
+self.jest_clay_last_destroyed = CardArea(
+        -10, -10,
+        CAI.discard_W,CAI.discard_H,
+        {card_limit = 1, type = 'joker'})
+self.jest_visage_last_sold = CardArea(
+        -10, -10,
+        CAI.discard_W,CAI.discard_H,
+        {card_limit = 1, type = 'joker'})
 '''


### PR DESCRIPTION
As described [in the issue I posted](https://github.com/survovoaneend/All-In-Jest/issues/102), Clay Joker and Visage cause an error when reloading because they don't save the copied joker correctly.

This PR implements the use of special card areas placed off-screen to store the last joker sold/destroyed for these jokers. Balatro handles saving cardareas, so the jokers stored in these will be saved and reloaded properly.

This works through the limited testing I did, but naturally there's a lot of edge-cases here so I don't guarantee it's bug-free. It just fixes the reload bug.