### PR TITLE
Hooked % balance into SMODs calculation and other % balance improvements

### DIFF
--- a/Items/Editions/glimmer.lua
+++ b/Items/Editions/glimmer.lua
@@ -22,7 +22,10 @@ local glimmer = {
     end,
     calculate = function(self, card, context)
 		if context.post_joker or (context.main_scoring and context.cardarea == G.play) then
-			balance_percent(card, (card.edition.percent*0.01))
+			-- balance_percent(card, (card.edition.percent*0.01))
+            return {
+                aij_balance_percent = card.edition.percent * 0.01
+            }
 		end
 	end,
     in_shop = true,

--- a/Items/Jokers/average_joe.lua
+++ b/Items/Jokers/average_joe.lua
@@ -27,7 +27,7 @@ local average_joe = {
   
     calculate = function(self, card, context)
       if context.joker_main then
-        -- balance_percent(context.blueprint_card or card,(card.ability.extra.percent*0.01))\
+        -- balance_percent(context.blueprint_card or card,(card.ability.extra.percent*0.01))
         return {
             aij_balance_percent = card.ability.extra.percent * 0.01
         }

--- a/Items/Jokers/average_joe.lua
+++ b/Items/Jokers/average_joe.lua
@@ -27,7 +27,10 @@ local average_joe = {
   
     calculate = function(self, card, context)
       if context.joker_main then
-        balance_percent(context.blueprint_card or card,(card.ability.extra.percent*0.01))
+        -- balance_percent(context.blueprint_card or card,(card.ability.extra.percent*0.01))\
+        return {
+            aij_balance_percent = card.ability.extra.percent * 0.01
+        }
       end
     end,
     in_pool = function(self, args)

--- a/Items/Jokers/candy_floss.lua
+++ b/Items/Jokers/candy_floss.lua
@@ -63,7 +63,10 @@ local candy_floss = {
             end
         end
         if context.joker_main then
-            balance_percent(context.blueprint_card or card ,(card.ability.extra.percent*0.01))
+            -- balance_percent(context.blueprint_card or card ,(card.ability.extra.percent*0.01))
+            return {
+                aij_balance_percent = card.ability.extra.percent * 0.01
+            }
         end
     end,
     in_pool = function(self, args)

--- a/Items/Jokers/columbina.lua
+++ b/Items/Jokers/columbina.lua
@@ -40,7 +40,10 @@ local columbina = {
 
       if context.joker_main then
         if card.ability.extra.percent > 0 then
-        return balance_percent(card,(card.ability.extra.percent*0.01))
+            -- return balance_percent(card,(card.ability.extra.percent*0.01))
+            return {
+                aij_balance_percent = card.ability.extra.percent * 0.01
+            }
         end
       end
     end,

--- a/Items/Jokers/goofball.lua
+++ b/Items/Jokers/goofball.lua
@@ -1,22 +1,22 @@
 local goofball = {
     object_type = "Joker",
     order = 233,
-    
+
     key = "goofball",
     config = {
-      extra = {
-        percent = 5
-      }
+        extra = {
+            percent = 5
+        }
     },
     rarity = 3,
-    pos = { x = 22, y = 8},
+    pos = { x = 22, y = 8 },
     atlas = 'joker_atlas',
     cost = 8,
     unlocked = true,
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
-  
+
     loc_vars = function(self, info_queue, card)
         return {
             vars = {
@@ -24,17 +24,23 @@ local goofball = {
             }
         }
     end,
-  
+
     calculate = function(self, card, context)
-      if context.individual and context.cardarea == G.play then
-        if context.other_card:is_face() then
-           
-            return {
-               balance_percent(context.other_card,(card.ability.extra.percent*0.01)),
-                card = card
-            }
+        if context.individual and context.cardarea == G.play then
+            if context.other_card:is_face() then
+                -- G.E_MANAGER:add_event(Event({
+                --     trigger = 'after',
+                --     func = (function()
+                --         card:juice_up(0.1)
+                --         return true
+                --     end)
+                -- }))
+                -- balance_percent(context.other_card, (card.ability.extra.percent * 0.01))
+                return {
+                    aij_balance_percent = card.ability.extra.percent * 0.01
+                }
+            end
         end
-      end
     end,
     in_pool = function(self, args)
         if G.GAME then
@@ -44,6 +50,6 @@ local goofball = {
         end
         return false
     end,
-  
+
 }
-return { name = {"Jokers"}, items = {goofball} }
+return { name = { "Jokers" }, items = { goofball } }

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -248,6 +248,7 @@ end
 
 table.insert(SMODS.calculation_keys, "aij_balance_percent")
 -- table.insert(SMODS.calculation_keys, 1, "aij_balance_percent") -- This version would put the effect at the start, making it go before chip/mult/etc. effects.
+local aij_balance_mixed = false
 local aij_original_smods_calculate_individal_effect = SMODS.calculate_individual_effect
 SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, from_edition)
     if key == "aij_balance_percent" then
@@ -263,33 +264,26 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         G.E_MANAGER:add_event(Event({
             trigger = 'immediate',
             func = (function()
-                ease_colour(G.C.UI_CHIPS, { 0.8, 0.45, 0.85, 1 })
-                ease_colour(G.C.UI_MULT, { 0.8, 0.45, 0.85, 1 })
-                G.E_MANAGER:add_event(Event({
-                    trigger = 'after',
-                    blockable = false,
-                    blocking = false,
-                    delay = 4.3,
-                    func = (function()
-                    ease_colour(G.C.UI_CHIPS, G.C.BLUE, 2)
-                    ease_colour(G.C.UI_MULT, G.C.RED, 2)
-                    return true
-                    end)
-                }))
-                G.E_MANAGER:add_event(Event({
-                    trigger = 'after',
-                    blockable = false,
-                    blocking = false,
-                    no_delete = true,
-                    delay = 6.3,
-                    func = (function()
-                    G.C.UI_CHIPS[1], G.C.UI_CHIPS[2], G.C.UI_CHIPS[3], G.C.UI_CHIPS[4] = G.C.BLUE[1], G.C.BLUE[2], G.C.BLUE[3],
-                        G.C.BLUE[4]
-                    G.C.UI_MULT[1], G.C.UI_MULT[2], G.C.UI_MULT[3], G.C.UI_MULT[4] = G.C.RED[1], G.C.RED[2], G.C.RED[3], G.C.RED
-                    [4]
-                    return true
-                    end)
-                }))
+                -- Mixes the chip and mult colours by the balance%
+                ease_colour(G.C.UI_CHIPS, mix_colours({ 0.8, 0.45, 0.85, 1 }, G.C.UI_CHIPS, amount))
+                ease_colour(G.C.UI_MULT, mix_colours({ 0.8, 0.45, 0.85, 1 }, G.C.UI_MULT, amount))
+                if not aij_balance_mixed then
+                    aij_balance_mixed = true
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'after',
+                        blockable = false,
+                        blocking = false,
+                        delay = 6.3,
+                        func = (function()
+                            if G.STATE ~= 2 then
+                                ease_colour(G.C.UI_CHIPS, G.C.BLUE, 2)
+                                ease_colour(G.C.UI_MULT, G.C.RED, 2)
+                                aij_balance_mixed = false
+                                return true
+                            end
+                        end)
+                    }))
+                end
                 return true
             end)
         }))

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -256,7 +256,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
             amount = 1
         end
         if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
-        hand_chips, mult = balance_percent(hand_chips, mult, amount)
+        hand_chips, mult = calculate_balance_percent_values(hand_chips, mult, amount)
 
         local text = (amount * 100) .. "%"
         update_hand_text({ delay = 0 }, { mult = mult, chips = hand_chips })
@@ -302,7 +302,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     return aij_original_smods_calculate_individal_effect(effect, scored_card, key, amount, from_edition)
 end
 
-function balance_percent(input_hand_chips, input_mult, percent)
+function calculate_balance_percent_values(input_hand_chips, input_mult, percent)
   local chip_mod = percent * input_hand_chips
   local mult_mod = percent * input_mult
   local avg = (chip_mod + mult_mod)/2

--- a/localization/default.lua
+++ b/localization/default.lua
@@ -216,7 +216,7 @@ return {
                 name = "Glimmer",
                 text = {
                     "{C:aij_plasma}Balances{} {C:attention}#1#%{} of",
-                    "{C:mult}Mult{} and {C:chips}Chips"
+                    "{C:chips}Chips{} and {C:mult}Mult{}"
                 }
             },
             e_aij_silver = {
@@ -812,13 +812,13 @@ return {
                 },
             },
             j_aij_columbina = { 
-                name = "Columbina", 
+                name = "Columbina",
                 text = {
-                    "{C:aij_plasma}Balance{} {C:attention}#1#%{} of {C:mult}Mult{} and",
-                    "{C:chips}Chips{}, increases by {C:attention}#2#%{}",
+                    "{C:aij_plasma}Balance{} {C:attention}#1#%{} of {C:chips}Chips{} and",
+                    "{C:mult}Mult{}, increases by {C:attention}#2#%{}",
                     "when a {C:spectral}Spectral{} card is",
                     "used"
-                } 
+                }
             },
             j_aij_j_file = { name = "J-File", text = { "" } },
             j_aij_bumper_sticker = { 
@@ -1785,8 +1785,8 @@ j_aij_chitty = {
             j_aij_candy_floss = { 
                 name = "Candy Floss", 
                 text = { 
-                    "{C:aij_plasma}Balance{} {C:attention}#1#%{} of {C:mult}Mult",
-                    "and {C:chips}Chips{}, decreases",
+                    "{C:aij_plasma}Balance{} {C:attention}#1#%{} of {C:chips}Chips{}",
+                    "and {C:mult}Mult{}, decreases",
                     "by {C:attention}#2#%{} at end of round"
                 } 
             },

--- a/localization/default.lua
+++ b/localization/default.lua
@@ -1458,9 +1458,8 @@ return {
             j_aij_goofball = { 
                 name = "Goofball", 
                 text = { 
-                    "{C:aij_plasma}Balance{} {C:attention}#1#%{} of {C:mult}Mult",
-                    "and {C:chips}Chips{} when any",
-                    "{C:attention}face{} card is {C:attention}scored"
+                    "Scored {C:attention}face{} cards {C:aij_plasma}balance{}",
+                    "{C:attention}#1#%{} of {C:chips}Chips{} and {C:mult}Mult{}"
                 } 
             },
             j_aij_heyokha = { name = "Heyókȟa", text = { "" } },


### PR DESCRIPTION
This was initially to change the animation speed of balancing, since the large delay between triggers was annoying me. Then it spiraled into multiple changes. Feel free to accept any, all, or none of this.

## Backend Calculation Change

Balance % jokers (as of current release: Average Joe, Candy Floss, Columbina, Goofball and the Glimmer edition) now return `aij_balance_percent`, like how over jokers can return `chips`, `mult`, etc.. An example of use is as follows: 

```lua
calculate = function(self, card, context)
    if context.joker_main then
        -- balance_percent(context.blueprint_card or card,(card.ability.extra.percent*0.01))
        return {
            aij_balance_percent = card.ability.extra.percent * 0.01
        }
    end
end,
```

The original `balance_percent` function is now split between a hook into `SMODS.calculate_individual_effect`, which performs the logic for `aij_balance_percent`, and a new `calculate_balance_percent_values` function which calculates the new chip and mult values.

## Gamplay changes

- %Balance effects now show the message "X%" rather than "Balanced"
- Balance effects no longer have delay (they will execute at the same pace as chips, mult, etc.), and are affected by calculation pitch.
- The chips/mult blending effect will now blend a percentage of the blue and red colour based on the amount of the effect.
  - This can stack with multiple balance% effects.
- %Balance now goes after chip/mult gain (relevant for goofball and glimmer).
- Goofball's description was changed to match Smiley Face a bit more
  - Was "Balance 5% of Mult and Chips when any face card is scored". Is now "Scored face cards balance 5% of Chips and Mult"
- Balance jokers wording all changed to "Chips and Mult" to match Plasma Deck.

### Video Demo of Gameplay Changes

https://github.com/user-attachments/assets/40cd48ed-555f-4ffe-822c-c978d4446e10

