### PR TITLE
fix: ensure perish_tally is properly initialized in Trefle spectral card

### DIFF
--- a/Items/Consumables/Spectrals/trefle.lua
+++ b/Items/Consumables/Spectrals/trefle.lua
@@ -97,8 +97,13 @@ local trefle_spectral = {
                     for k, v in pairs(G.shared_stickers) do
                         if victim_joker.ability[k] then
                             new_joker.ability[k] = true
+                            -- ensure perish_tally is initialized correctly
+                            if k == "perishable" and new_joker.ability.perish_tally == nil then
+                                new_joker.ability.perish_tally = G.GAME.perishable_rounds or 5
+                            end
                         end
                     end
+                    
                     new_joker:start_materialize({ G.C.SPECTRAL, G.C.WHITE })
                     new_joker:set_edition(victim_joker.edition)
                 end


### PR DESCRIPTION
When using the Trefle spectral card to replace a perishable joker, the new joker's perish_tally was not being properly initialized, which could cause issues with the perishable behavior. This fix ensures that when a new joker inherits the perishable ability from the replaced joker, its perish_tally is correctly set to the default value (G.GAME.perishable_rounds or 5) if it was nil.