### PR TITLE
A variety of joker improvements

### DIFF
--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -20,7 +20,14 @@ local clay_joker = {
     loc_vars = function(self, info_queue, card)
         if G.jest_clay_last_destroyed and G.jest_clay_last_destroyed.cards[1] then
             local other_joker = G.jest_clay_last_destroyed.cards[1]
-            info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
+            local other_vars
+            if other_joker.config.center.loc_vars then
+                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker)
+            else
+                other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
+            end
+            other_joker.config.center.specific_vars = other_vars
+            info_queue[#info_queue + 1] = other_joker.config.center
         end
         return { vars = {} }
     end,

--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -22,11 +22,12 @@ local clay_joker = {
             local other_joker = G.jest_clay_last_destroyed.cards[1]
             local other_vars
             if other_joker.config.center.loc_vars then
-                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker)
+                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker).vars
             else
                 other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
             end
             other_joker.config.center.specific_vars = other_vars
+            other_joker.config.center.specific_vars.aij_clay = true
             info_queue[#info_queue + 1] = other_joker.config.center
         end
         return { vars = {} }

--- a/Items/Jokers/scary_story.lua
+++ b/Items/Jokers/scary_story.lua
@@ -41,6 +41,7 @@ local scary_story = {
                                 v:set_edition({negative = true}, true, true)
                                 play_sound('negative', 1.5, 0.4)
                                 v:juice_up(0.3, 0.2)
+card:juice_up(0.3, 0.2)
                                 return true
                               end
                             }))

--- a/Items/Jokers/scary_story.lua
+++ b/Items/Jokers/scary_story.lua
@@ -28,9 +28,7 @@ local scary_story = {
 
     calculate = function(self, card, context)
       if context.open_booster and context.card.ability.name and not context.blueprint then
-        if (context.open_booster and context.card.ability.name == 'Standard Pack' or
-        context.open_booster and context.card.ability.name == 'Jumbo Standard Pack' or
-        context.open_booster and context.card.ability.name == 'Mega Standard Pack') then
+        if (context.open_booster and context.card.config.center.kind == 'Standard') then
           G.E_MANAGER:add_event(Event({
             func = function()
                 if G.pack_cards and G.pack_cards.cards and G.pack_cards.cards[1] and G.pack_cards.VT.y < G.ROOM.T.h then

--- a/Items/Jokers/the_jester.lua
+++ b/Items/Jokers/the_jester.lua
@@ -4,12 +4,12 @@ local the_jester = {
 
     key = "the_jester",
     config = {
-      extra = {
-        active = true,
-      }
+        extra = {
+            active = true,
+        }
     },
     rarity = 2,
-    pos = { x = 17, y = 9},
+    pos = { x = 17, y = 9 },
     atlas = 'joker_atlas',
     cost = 7,
     unlocked = true,
@@ -34,32 +34,45 @@ local the_jester = {
         end
     end,
   
+    add_to_deck = function(self, card, from_debuff)
+        if card.ability.extra.active then
+            local eval = function() return card.ability.extra.active end
+            juice_card_until(card, eval, true)
+        end
+    end,
+
     calculate = function(self, card, context)
-      if context.selling_card then 
-        if context.card ~= card then
-            if context.card.ability.set == "Joker" and card.ability.extra.active then
-          
-              G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.4, func = function()
-                if G.consumeables.config.card_limit > #G.consumeables.cards then
-                    play_sound('timpani')
-                    local _card = create_card(nil, G.consumeables, nil, nil, nil, nil, 'c_fool', nil)
-                    _card:add_to_deck()
-                    G.consumeables:emplace(_card)
-                    card:juice_up(0.3, 0.3)
+        if context.selling_card then
+            if context.card ~= card then
+                if context.card.ability.set == "Joker" and card.ability.extra.active then
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'after',
+                        delay = 0.4,
+                        func = function()
+                            if G.consumeables.config.card_limit > #G.consumeables.cards then
+                                play_sound('timpani')
+                                local _card = create_card(nil, G.consumeables, nil, nil, nil, nil, 'c_fool', nil)
+                                _card:add_to_deck()
+                                G.consumeables:emplace(_card)
+                                card:juice_up(0.3, 0.3)
+                            end
+                            return {
+                                true,
+                                message = 'The Fool'
+                            }
+                        end
+                    }))
                     card.ability.extra.active = false
+                    delay(0.6)
                 end
-                return {
-                  true,
-                  message = 'The Fool'
-                }   end }))
-            delay(0.6)
             end
         end
-      end
-      if context.end_of_round then
-        card.ability.extra.active = true
-      end
+        if context.end_of_round and not card.ability.extra.active then
+            card.ability.extra.active = true
+            local eval = function() return card.ability.extra.active end
+            juice_card_until(card, eval, true)
+        end
     end
-  
+
 }
-return { name = {"Jokers"}, items = {the_jester} }
+return { name = { "Jokers" }, items = { the_jester } }

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -20,7 +20,14 @@ local visage = {
     loc_vars = function(self, info_queue, card)
         if G.jest_visage_last_sold and G.jest_visage_last_sold.cards[1] then
             local other_joker = G.jest_visage_last_sold.cards[1]
-            info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
+            local other_vars
+            if other_joker.config.center.loc_vars then
+                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker)
+            else
+                other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
+            end
+            other_joker.config.center.specific_vars = other_vars
+            info_queue[#info_queue + 1] = other_joker.config.center
         end
         return { vars = {} }
     end,

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -22,11 +22,12 @@ local visage = {
             local other_joker = G.jest_visage_last_sold.cards[1]
             local other_vars
             if other_joker.config.center.loc_vars then
-                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker)
+                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker).vars
             else
                 other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
             end
             other_joker.config.center.specific_vars = other_vars
+            other_joker.config.center.specific_vars.aij_visage = true
             info_queue[#info_queue + 1] = other_joker.config.center
         end
         return { vars = {} }

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -1366,6 +1366,7 @@ self.jest_visage_last_sold = CardArea(
 '''
 
 # Patch related to better Clay Joker and Visage Info Queue
+# For vanilla jokers
 [[patches]]
 [patches.pattern]
 target = "functions/common_events.lua"
@@ -1374,4 +1375,15 @@ position = "after"
 match_indent = true
 payload = '''
 specific_vars = _c.specific_vars or specific_vars
+'''
+# For modded jokers
+[[patches]]
+[patches.pattern]
+target = '''=[SMODS _ "src/game_object.lua"]'''
+pattern = "if target.vars.is_info_queue then target.is_info_queue = true; target.vars.is_info_queue = nil end"
+position = "after"
+match_indent = true
+payload = '''
+if target.vars.aij_visage then card = G.jest_visage_last_sold.cards[1]; target.vars.aij_visage = nil end -- All in Jest
+if target.vars.aij_clay then card = G.jest_clay_last_destroyed.cards[1]; target.vars.aij_clay = nil end -- All in Jest
 '''

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -1364,3 +1364,14 @@ self.jest_visage_last_sold = CardArea(
         CAI.discard_W,CAI.discard_H,
         {card_limit = 1, type = 'joker'})
 '''
+
+# Patch related to better Clay Joker and Visage Info Queue
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "specific_vars = ret[1]"
+position = "after"
+match_indent = true
+payload = '''
+specific_vars = _c.specific_vars or specific_vars
+'''

--- a/localization/default.lua
+++ b/localization/default.lua
@@ -1123,9 +1123,9 @@ return {
             j_aij_the_jester = {
                 name = "The Jester",
                 text = {
-                    "Selling a {C:attention}Joker{} creates",
-                    "{C:tarot}The Fool{} card",
-                    "{C:inactive}(Works once per round){C:inactive}",
+                    "The first {C:attention}Joker{}",
+                    "sold each round",
+                    "creates {C:tarot}The Fool{}",
                     "{C:inactive}#1#{}"
                 },
                 -- TODO use juice until


### PR DESCRIPTION
I have implemented these over a little while and I'm putting these in a PR now ahead of the upcoming update. These affect a handful of jokers, feel free to accept some, all, or none of it:

- Scary Story now checks the 'kind' attribute in the opened booster rather than its name (for if other mods add extra standard packs)
- Scary Story will juice up when creating a negative card (See below)
- Stargazy Pie has a better animation now (see below)
- Visage and Clay Joker will have their info queue match the variables of the previously sold/destroyed joker. (see below)
  - Note that it says "retrigger next 4 planets" on visage, currently it will default to "next 5 planets". This applies for any scaling joker.
- The Jester will now juice until use.
- The Jester has different wording which eliminates the (once per round) and in my opinion reads better. (see below)


https://github.com/user-attachments/assets/c97ea5c0-bfa6-4397-bd96-3a191d2c1049

https://github.com/user-attachments/assets/e0ce670c-7c62-400e-acb6-147120db68f9

https://github.com/user-attachments/assets/12df13b0-6ccf-42cc-abcc-2ee19865a9b4

<img width="612" height="330" alt="image" src="https://github.com/user-attachments/assets/c6d203c7-0062-4722-b2db-946f1a44831c" />