### PR TITLE
Tries to fix a crash with Visage and Clay Joker

### DIFF
--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -18,8 +18,8 @@ local clay_joker = {
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)
-        if G.jest_clay_last_destroyed and G.jest_clay_last_destroyed.cards[1] then
-            local other_joker = G.jest_clay_last_destroyed.cards[1]
+        if G.all_in_jest and G.all_in_jest.clay_last_destroyed and G.all_in_jest.clay_last_destroyed.cards[1] then
+            local other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
             local other_vars
             if other_joker.config.center.loc_vars then
                 other_vars = other_joker.config.center:loc_vars(info_queue, other_joker).vars
@@ -34,8 +34,10 @@ local clay_joker = {
     end,
 
     calculate = function(self, card, context)
-        local other_joker = G.jest_clay_last_destroyed.cards[1]
-        return SMODS.blueprint_effect(card, other_joker, context)
+        if G.all_in_jest and G.all_in_jest.clay_last_destroyed and G.all_in_jest.clay_last_destroyed.cards[1] then
+            local other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
+            return SMODS.blueprint_effect(card, other_joker, context)
+        end
     end
 
 }
@@ -44,10 +46,10 @@ function Card:start_dissolve(dissolve_colours, silent, dissolve_time_fac, no_jui
     local ref = start_dissolve_ref(self, dissolve_colours, silent, dissolve_time_fac, no_juice)
     if G.jokers and self.ability.set == 'Joker' then
         if not self.ability.jest_sold_self then
-            G.jest_clay_last_destroyed.cards = {}
+            G.all_in_jest.clay_last_destroyed.cards = {}
             if not (self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker') then
                 local copied_card = copy_card(self, nil, 0) -- Creates a copy with 0 scale
-                G.jest_clay_last_destroyed:emplace(copied_card)
+                G.all_in_jest.clay_last_destroyed:emplace(copied_card)
             end
         end
     end

--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -20,14 +20,19 @@ local clay_joker = {
     loc_vars = function(self, info_queue, card)
         if G.all_in_jest and G.all_in_jest.clay_last_destroyed and G.all_in_jest.clay_last_destroyed.cards[1] then
             local other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
-            local other_vars
+            local other_vars = nil
             if other_joker.config.center.loc_vars then
-                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker).vars
+                local ret = other_joker.config.center:loc_vars(info_queue, other_joker)
+                if ret then
+                    other_vars = ret.vars
+                end
             else
                 other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
             end
-            other_joker.config.center.specific_vars = other_vars
-            other_joker.config.center.specific_vars.aij_clay = true
+            if other_vars then
+                other_joker.config.center.specific_vars = other_vars
+                other_joker.config.center.specific_vars.aij_clay = true
+            end
             info_queue[#info_queue + 1] = other_joker.config.center
         end
         return { vars = {} }

--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -22,7 +22,7 @@ local clay_joker = {
             local other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
             local other_vars = nil
             if other_joker.config.center.loc_vars then
-                local ret = other_joker.config.center:loc_vars(info_queue, other_joker)
+                local ret = other_joker.config.center:loc_vars({}, other_joker)
                 if ret then
                     other_vars = ret.vars
                 end

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -18,24 +18,28 @@ local visage = {
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)
-        if G.jest_visage_last_sold and G.jest_visage_last_sold.cards[1] then
-            local other_joker = G.jest_visage_last_sold.cards[1]
+        if G.all_in_jest and G.all_in_jest.visage_last_sold and G.all_in_jest.visage_last_sold.cards[1] then
+            local other_joker = G.all_in_jest.visage_last_sold.cards[1]
             local other_vars
             if other_joker.config.center.loc_vars then
                 other_vars = other_joker.config.center:loc_vars(info_queue, other_joker).vars
             else
                 other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
             end
-            other_joker.config.center.specific_vars = other_vars
-            other_joker.config.center.specific_vars.aij_visage = true
+            if other_vars then
+                other_joker.config.center.specific_vars = other_vars
+                other_joker.config.center.specific_vars.aij_visage = true
+            end
             info_queue[#info_queue + 1] = other_joker.config.center
         end
         return { vars = {} }
     end,
 
     calculate = function(self, card, context)
-        local other_joker = G.jest_visage_last_sold.cards[1]
-        return SMODS.blueprint_effect(card, other_joker, context)
+        if G.all_in_jest and G.all_in_jest.visage_last_sold and G.all_in_jest.visage_last_sold.cards[1] then
+            local other_joker = G.all_in_jest.visage_last_sold.cards[1]
+            return SMODS.blueprint_effect(card, other_joker, context)
+        end
     end
 
 }
@@ -43,10 +47,10 @@ local sell_card_ref = Card.sell_card
 function Card:sell_card()
     local ref = sell_card_ref(self)
     if G.jokers and self.ability.set == 'Joker' then
-        G.jest_visage_last_sold.cards = {}
+        G.all_in_jest.visage_last_sold.cards = {}
         if not (self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker') then
             local copied_card = copy_card(self, nil, 0) -- Creates a copy with 0 scale
-            G.jest_visage_last_sold:emplace(copied_card)
+            G.all_in_jest.visage_last_sold:emplace(copied_card)
         end
     end
     return ref

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -22,7 +22,7 @@ local visage = {
             local other_joker = G.all_in_jest.visage_last_sold.cards[1]
             local other_vars = nil
             if other_joker.config.center.loc_vars then
-                local ret = other_joker.config.center:loc_vars(info_queue, other_joker)
+                local ret = other_joker.config.center:loc_vars({}, other_joker)
                 if ret then
                     other_vars = ret.vars
                 end

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -20,9 +20,12 @@ local visage = {
     loc_vars = function(self, info_queue, card)
         if G.all_in_jest and G.all_in_jest.visage_last_sold and G.all_in_jest.visage_last_sold.cards[1] then
             local other_joker = G.all_in_jest.visage_last_sold.cards[1]
-            local other_vars
+            local other_vars = nil
             if other_joker.config.center.loc_vars then
-                other_vars = other_joker.config.center:loc_vars(info_queue, other_joker).vars
+                local ret = other_joker.config.center:loc_vars(info_queue, other_joker)
+                if ret then
+                    other_vars = ret.vars
+                end
             else
                 other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
             end

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -1322,9 +1322,9 @@ payload = '''
 if self.ability.name == 'j_aij_clay_joker' or self.ability.name == 'j_aij_visage' or (self.ability.name == 'j_aij_czar' or self.ability.name == 'j_aij_joker_png') then
 	local other_joker = nil
     if self.ability.name == 'j_aij_visage' then
-        other_joker = G.jest_visage_last_sold.cards[1]
+        other_joker = G.all_in_jest.visage_last_sold.cards[1]
     elseif self.ability.name == 'j_aij_clay_joker' then
-        other_joker = G.jest_clay_last_destroyed.cards[1]
+        other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
     end
     if (other_joker and other_joker ~= self and other_joker.config and other_joker.config.center.blueprint_compat) or (self.ability.name == 'j_aij_czar' or self.ability.name == 'j_aij_joker_png') then
         self.ability.blueprint_compat = 'compatible'
@@ -2650,11 +2650,11 @@ self.all_in_jest.joker_png = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 99999999, type = 'joker'})
-self.jest_clay_last_destroyed = CardArea(
+self.all_in_jest.clay_last_destroyed = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 1, type = 'joker'})
-self.jest_visage_last_sold = CardArea(
+self.all_in_jest.visage_last_sold = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 1, type = 'joker'})
@@ -2679,6 +2679,6 @@ pattern = "if target.vars.is_info_queue then target.is_info_queue = true; target
 position = "after"
 match_indent = true
 payload = '''
-if target.vars.aij_visage then card = G.jest_visage_last_sold.cards[1]; target.vars.aij_visage = nil end -- All in Jest
-if target.vars.aij_clay then card = G.jest_clay_last_destroyed.cards[1]; target.vars.aij_clay = nil end -- All in Jest
+if target.vars.aij_visage then card = G.all_in_jest.visage_last_sold.cards[1]; target.vars.aij_visage = nil end -- All in Jest
+if target.vars.aij_clay then card = G.all_in_jest.clay_last_destroyed.cards[1]; target.vars.aij_clay = nil end -- All in Jest
 '''


### PR DESCRIPTION
There was a crash that I'm pretty sure was caused by selling/destroying a joker that does not utilise the `loc_vars` function. This tries to fix that.

While I'm here I also implemented two other changes:
- Jokers should no longer show duplicate info queues (try selling Lucky Seven for example and hovering over Visage)
- Moved Cardareas to be inside `G.all_in_jest` to be consistent with other code