### PR TITLE
Fixes reload issues for Visage, Clay Joker, Joker.png and Czar

### DIFF
--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -18,8 +18,8 @@ local clay_joker = {
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest.clay_last_destroyed and G.all_in_jest.clay_last_destroyed.cards[1] then
-            local other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
+        if G.all_in_jest and G.all_in_jest_clay_last_destroyed and G.all_in_jest_clay_last_destroyed.cards[1] then
+            local other_joker = G.all_in_jest_clay_last_destroyed.cards[1]
             local other_vars = nil
             if other_joker.config.center.loc_vars then
                 local ret = other_joker.config.center:loc_vars({}, other_joker)
@@ -39,8 +39,8 @@ local clay_joker = {
     end,
 
     calculate = function(self, card, context)
-        if G.all_in_jest and G.all_in_jest.clay_last_destroyed and G.all_in_jest.clay_last_destroyed.cards[1] then
-            local other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
+        if G.all_in_jest and G.all_in_jest_clay_last_destroyed and G.all_in_jest_clay_last_destroyed.cards[1] then
+            local other_joker = G.all_in_jest_clay_last_destroyed.cards[1]
             return SMODS.blueprint_effect(card, other_joker, context)
         end
     end
@@ -51,10 +51,10 @@ function Card:start_dissolve(dissolve_colours, silent, dissolve_time_fac, no_jui
     local ref = start_dissolve_ref(self, dissolve_colours, silent, dissolve_time_fac, no_juice)
     if G.jokers and self.ability.set == 'Joker' then
         if not self.ability.jest_sold_self then
-            G.all_in_jest.clay_last_destroyed.cards = {}
+            G.all_in_jest_clay_last_destroyed.cards = {}
             if not (self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker') then
                 local copied_card = copy_card(self, nil, 0) -- Creates a copy with 0 scale
-                G.all_in_jest.clay_last_destroyed:emplace(copied_card)
+                G.all_in_jest_clay_last_destroyed:emplace(copied_card)
             end
         end
     end

--- a/Items/Jokers/clay_joker.lua
+++ b/Items/Jokers/clay_joker.lua
@@ -18,7 +18,7 @@ local clay_joker = {
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest_clay_last_destroyed and G.all_in_jest_clay_last_destroyed.cards[1] then
+        if G.all_in_jest_clay_last_destroyed and G.all_in_jest_clay_last_destroyed.cards[1] then
             local other_joker = G.all_in_jest_clay_last_destroyed.cards[1]
             local other_vars = nil
             if other_joker.config.center.loc_vars then
@@ -39,7 +39,7 @@ local clay_joker = {
     end,
 
     calculate = function(self, card, context)
-        if G.all_in_jest and G.all_in_jest_clay_last_destroyed and G.all_in_jest_clay_last_destroyed.cards[1] then
+        if G.all_in_jest_clay_last_destroyed and G.all_in_jest_clay_last_destroyed.cards[1] then
             local other_joker = G.all_in_jest_clay_last_destroyed.cards[1]
             return SMODS.blueprint_effect(card, other_joker, context)
         end

--- a/Items/Jokers/coulrorachne.lua
+++ b/Items/Jokers/coulrorachne.lua
@@ -18,6 +18,7 @@ local coulrorachne = {
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
+    perishable_compat = false,
   
     loc_vars = function(self, info_queue, card)
         return {

--- a/Items/Jokers/czar.lua
+++ b/Items/Jokers/czar.lua
@@ -28,25 +28,25 @@ local czar = {
         end
         local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
         SMODS.bypass_create_card_edition = true
-        local joker = create_card('Joker', G.all_in_jest.czar, nil, nil, true, nil, joker_center.key, 'czar')
+        local joker = create_card('Joker', G.all_in_jest_czar, nil, nil, true, nil, joker_center.key, 'czar')
         SMODS.bypass_create_card_edition = nil
-        G.all_in_jest.czar:emplace(joker)
+        G.all_in_jest_czar:emplace(joker)
         joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-        joker.ability.all_in_jest.czar = tostring(card)
+        joker.ability.all_in_jest_czar = tostring(card)
     end,
 
     remove_from_deck = function(self, card, from_debuff)
-        for k,v in pairs(G.all_in_jest.czar.cards) do
-            if v.ability.all_in_jest and v.ability.all_in_jest.czar == tostring(card) then
+        for k,v in pairs(G.all_in_jest_czar.cards) do
+            if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
                 v:remove()
             end
         end
     end,
 
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest.czar and G.all_in_jest.czar.cards then
-            for k,v in pairs(G.all_in_jest.czar.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest.czar == tostring(card) then
+        if G.all_in_jest and G.all_in_jest_czar and G.all_in_jest_czar.cards then
+            for k,v in pairs(G.all_in_jest_czar.cards) do
+                if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
                     local other_joker = v
                     info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
                 end
@@ -70,25 +70,25 @@ local czar = {
                 end
             end
             local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
-            for k,v in pairs(G.all_in_jest.czar.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest.czar == tostring(card) then
+            for k,v in pairs(G.all_in_jest_czar.cards) do
+                if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
                     v:remove()
                 end
             end
             SMODS.bypass_create_card_edition = true
-            local joker = create_card('Joker', G.all_in_jest.czar, nil, nil, true, nil, joker_center.key, 'czar')
+            local joker = create_card('Joker', G.all_in_jest_czar, nil, nil, true, nil, joker_center.key, 'czar')
             SMODS.bypass_create_card_edition = nil
-            G.all_in_jest.czar:emplace(joker)
+            G.all_in_jest_czar:emplace(joker)
             joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-            joker.ability.all_in_jest.czar = tostring(card)
+            joker.ability.all_in_jest_czar = tostring(card)
             if not context.blueprint then
                 return {
                     message = localize('k_reset'),
                 }
             end
         end
-        for k,v in pairs(G.all_in_jest.czar.cards) do
-            if v.ability.all_in_jest and v.ability.all_in_jest.czar == tostring(card) then
+        for k,v in pairs(G.all_in_jest_czar.cards) do
+            if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
                 local other_joker = v
                 return SMODS.blueprint_effect(card, other_joker, context)
             end

--- a/Items/Jokers/czar.lua
+++ b/Items/Jokers/czar.lua
@@ -1,14 +1,8 @@
 local spawn_czar_joker = function (card)
     local jokers = {}
-    for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-        if v.discovered and v.blueprint_compat and v.perishable_compat and not G.GAME.banned_keys[v.key] then
-            if v.in_pool and type(v.in_pool) == 'function' then
-                if v:in_pool() then
-                    jokers[#jokers+1] = v
-                end
-            else
-                jokers[#jokers+1] = v
-            end
+    for _,v in pairs(G.P_CENTER_POOLS["Joker"]) do
+        if v.key ~= "j_aij_czar" and All_in_Jest.expanded_copier_compat(v, true) then
+            jokers[#jokers+1] = v
         end
     end
     local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
@@ -40,7 +34,7 @@ local czar = {
     end,
 
     remove_from_deck = function(self, card, from_debuff)
-        for k,v in pairs(G.all_in_jest_czar.cards) do
+        for _,v in pairs(G.all_in_jest_czar.cards) do
             if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                 v:remove()
             end
@@ -49,7 +43,7 @@ local czar = {
 
     loc_vars = function(self, info_queue, card)
         if G.all_in_jest_czar.cards then
-            for k,v in pairs(G.all_in_jest_czar.cards) do
+            for _,v in pairs(G.all_in_jest_czar.cards) do
                 if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                     local other_joker = v
                     local other_vars = nil
@@ -74,7 +68,7 @@ local czar = {
 
     calculate = function(self, card, context)
         if context.reroll_shop then
-            for k,v in pairs(G.all_in_jest_czar.cards) do
+            for _,v in pairs(G.all_in_jest_czar.cards) do
                 if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                     v:remove()
                 end
@@ -86,8 +80,8 @@ local czar = {
                 }
             end
         end
-        for k,v in pairs(G.all_in_jest_czar.cards) do
-            if v.ability.all_in_jest.czar == card.unique_val then
+        for _,v in pairs(G.all_in_jest_czar.cards) do
+            if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                 local other_joker = v
                 return SMODS.blueprint_effect(card, other_joker, context)
             end

--- a/Items/Jokers/czar.lua
+++ b/Items/Jokers/czar.lua
@@ -1,10 +1,14 @@
 local spawn_czar_joker = function (card)
     local jokers = {}
-    for _,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-        if v.key ~= "j_aij_czar" and All_in_Jest.expanded_copier_compat(v, true) then
-            jokers[#jokers+1] = v
+    -- for rarity, _ in pairs(SMODS.Rarity.obj_table) do
+        -- for _, key in pairs(get_current_pool("Joker"), rarity) do
+        for _, key in pairs(get_current_pool("Joker")) do
+            local center = G.P_CENTERS[key]
+            if key ~= "j_aij_czar" and key ~= "UNAVAILABLE" and All_in_Jest.expanded_copier_compat(center, true) then
+                jokers[#jokers+1] = center
+            end
         end
-    end
+    -- end
     local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
     SMODS.bypass_create_card_edition = true
     local joker = create_card('Joker', G.all_in_jest_czar, nil, nil, true, nil, joker_center.key, 'czar')

--- a/Items/Jokers/czar.lua
+++ b/Items/Jokers/czar.lua
@@ -1,3 +1,25 @@
+local spawn_czar_joker = function (card)
+    local jokers = {}
+    for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
+        if v.discovered and v.blueprint_compat and v.perishable_compat and not G.GAME.banned_keys[v.key] then
+            if v.in_pool and type(v.in_pool) == 'function' then
+                if v:in_pool() then
+                    jokers[#jokers+1] = v
+                end
+            else
+                jokers[#jokers+1] = v
+            end
+        end
+    end
+    local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
+    SMODS.bypass_create_card_edition = true
+    local joker = create_card('Joker', G.all_in_jest_czar, nil, nil, true, nil, joker_center.key, 'czar')
+    SMODS.bypass_create_card_edition = nil
+    G.all_in_jest_czar:emplace(joker)
+    joker.ability.all_in_jest = joker.ability.all_in_jest or {}
+    joker.ability.all_in_jest.czar = card.unique_val
+end
+
 local czar = {
     object_type = "Joker",
     order = 365,
@@ -14,39 +36,21 @@ local czar = {
     eternal_compat = true,
     
     add_to_deck = function(self, card, from_debuff)
-        local jokers = {}
-        for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-            if v.discovered and v.blueprint_compat and v.perishable_compat then
-                if v.in_pool and type(v.in_pool) == 'function' then
-                    if v:in_pool() then
-                        jokers[#jokers+1] = v
-                    end
-                else
-                    jokers[#jokers+1] = v
-                end
-            end
-        end
-        local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
-        SMODS.bypass_create_card_edition = true
-        local joker = create_card('Joker', G.all_in_jest_czar, nil, nil, true, nil, joker_center.key, 'czar')
-        SMODS.bypass_create_card_edition = nil
-        G.all_in_jest_czar:emplace(joker)
-        joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-        joker.ability.all_in_jest_czar = tostring(card)
+        spawn_czar_joker(card)
     end,
 
     remove_from_deck = function(self, card, from_debuff)
         for k,v in pairs(G.all_in_jest_czar.cards) do
-            if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
+            if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                 v:remove()
             end
         end
     end,
 
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest_czar and G.all_in_jest_czar.cards then
+        if G.all_in_jest_czar.cards then
             for k,v in pairs(G.all_in_jest_czar.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
+                if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                     local other_joker = v
                     info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
                 end
@@ -57,30 +61,12 @@ local czar = {
 
     calculate = function(self, card, context)
         if context.reroll_shop then
-            local jokers = {}
-            for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-                if v.discovered and v.blueprint_compat then
-                    if v.in_pool and type(v.in_pool) == 'function' then
-                        if v:in_pool() then
-                            jokers[#jokers+1] = v
-                        end
-                    else
-                        jokers[#jokers+1] = v
-                    end
-                end
-            end
-            local joker_center = pseudorandom_element(jokers, pseudoseed('czar'))
             for k,v in pairs(G.all_in_jest_czar.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
+                if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                     v:remove()
                 end
             end
-            SMODS.bypass_create_card_edition = true
-            local joker = create_card('Joker', G.all_in_jest_czar, nil, nil, true, nil, joker_center.key, 'czar')
-            SMODS.bypass_create_card_edition = nil
-            G.all_in_jest_czar:emplace(joker)
-            joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-            joker.ability.all_in_jest_czar = tostring(card)
+            spawn_czar_joker(card)
             if not context.blueprint then
                 return {
                     message = localize('k_reset'),
@@ -88,7 +74,7 @@ local czar = {
             end
         end
         for k,v in pairs(G.all_in_jest_czar.cards) do
-            if v.ability.all_in_jest and v.ability.all_in_jest_czar == tostring(card) then
+            if v.ability.all_in_jest.czar == card.unique_val then
                 local other_joker = v
                 return SMODS.blueprint_effect(card, other_joker, context)
             end

--- a/Items/Jokers/czar.lua
+++ b/Items/Jokers/czar.lua
@@ -52,6 +52,19 @@ local czar = {
             for k,v in pairs(G.all_in_jest_czar.cards) do
                 if v.ability.all_in_jest and v.ability.all_in_jest.czar == card.unique_val then
                     local other_joker = v
+                    local other_vars = nil
+                    if other_joker.config.center.loc_vars then
+                        local ret = other_joker.config.center:loc_vars({}, other_joker)
+                        if ret then
+                            other_vars = ret.vars
+                        end
+                    else
+                        other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
+                    end
+                    if other_vars then
+                        other_joker.config.center.specific_vars = other_vars
+                        other_joker.config.center.specific_vars.aij_czar = other_joker
+                    end
                     info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
                 end
             end

--- a/Items/Jokers/joker_png.lua
+++ b/Items/Jokers/joker_png.lua
@@ -1,10 +1,14 @@
 local spawn_joker_png_joker = function (card)
     local jokers = {}
-    for _,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-        if v.key ~= "j_aij_joker_png" and All_in_Jest.expanded_copier_compat(v, true) then
-            jokers[#jokers+1] = v
+    -- for rarity, _ in pairs(SMODS.Rarity.obj_table) do
+        -- for _, key in pairs(get_current_pool("Joker"), rarity) do
+        for _, key in pairs(get_current_pool("Joker")) do
+            local center = G.P_CENTERS[key]
+            if key ~= "j_aij_joker_png" and key ~= "UNAVAILABLE" and All_in_Jest.expanded_copier_compat(center, true) then
+                jokers[#jokers+1] = center
+            end
         end
-    end
+    -- end
     local joker_center, index = pseudorandom_element(jokers, pseudoseed('joker_png'))
     SMODS.bypass_create_card_edition = true
     local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')

--- a/Items/Jokers/joker_png.lua
+++ b/Items/Jokers/joker_png.lua
@@ -44,17 +44,17 @@ local joker_png = {
                 end
             end
             local joker_center = pseudorandom_element(jokers, pseudoseed('joker_png'))
-            for k,v in pairs(G.all_in_jest.joker_png.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == tostring(card) then
+            for k,v in pairs(G.all_in_jest_joker_png.cards) do
+                if v.ability.all_in_jest and v.ability.all_in_jest_joker_png == tostring(card) then
                     v:remove()
                 end
             end
             SMODS.bypass_create_card_edition = true
-            local joker = create_card('Joker', G.all_in_jest.joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
+            local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
             SMODS.bypass_create_card_edition = nil
-            G.all_in_jest.joker_png:emplace(joker)
+            G.all_in_jest_joker_png:emplace(joker)
             joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-            joker.ability.all_in_jest.joker_png = tostring(card)
+            joker.ability.all_in_jest_joker_png = tostring(card)
             card:juice_up(0.3, 0.5)
             card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_reset')})
         end,
@@ -75,11 +75,11 @@ local joker_png = {
         end
         local joker_center = pseudorandom_element(jokers, pseudoseed('joker_png'))
         SMODS.bypass_create_card_edition = true
-        local joker = create_card('Joker', G.all_in_jest.joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
+        local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
         SMODS.bypass_create_card_edition = nil
-        G.all_in_jest.joker_png:emplace(joker)
+        G.all_in_jest_joker_png:emplace(joker)
         joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-        joker.ability.all_in_jest.joker_png = tostring(card)
+        joker.ability.all_in_jest_joker_png = tostring(card)
     end,
 
     update = function(self, card, dt)
@@ -89,9 +89,9 @@ local joker_png = {
     end,
   
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest.joker_png then
-            for k,v in pairs(G.all_in_jest.joker_png.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == tostring(card) then
+        if G.all_in_jest and G.all_in_jest_joker_png then
+            for k,v in pairs(G.all_in_jest_joker_png.cards) do
+                if v.ability.all_in_jest and v.ability.all_in_jest_joker_png == tostring(card) then
                     local other_joker = v
                     info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
                 end
@@ -108,8 +108,8 @@ local joker_png = {
     end,
   
     calculate = function(self, card, context)
-        for k,v in pairs(G.all_in_jest.joker_png.cards) do
-            if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == tostring(card) then
+        for k,v in pairs(G.all_in_jest_joker_png.cards) do
+            if v.ability.all_in_jest and v.ability.all_in_jest_joker_png == tostring(card) then
                 local other_joker = v
                 return SMODS.blueprint_effect(card, other_joker, context)
             end

--- a/Items/Jokers/joker_png.lua
+++ b/Items/Jokers/joker_png.lua
@@ -1,3 +1,27 @@
+local spawn_joker_png_joker = function (card)
+    local jokers = {}
+    for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
+        if v.discovered and v.blueprint_compat and v.perishable_compat and v.rarity ~= 4 and not G.GAME.banned_keys[v.key] then
+            if v.in_pool and type(v.in_pool) == 'function' then
+                if v:in_pool() then
+                    jokers[#jokers+1] = v
+                end
+            else
+                jokers[#jokers+1] = v
+            end
+        end
+    end
+    local joker_center, index = pseudorandom_element(jokers, pseudoseed('joker_png'))
+    sendDebugMessage(joker_center.key, "AIJ")
+    sendDebugMessage(index, "AIJ")
+    SMODS.bypass_create_card_edition = true
+    local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
+    SMODS.bypass_create_card_edition = nil
+    G.all_in_jest_joker_png:emplace(joker)
+    joker.ability.all_in_jest = joker.ability.all_in_jest or {}
+    joker.ability.all_in_jest.joker_png = card.unique_val
+end
+
 local joker_png = {
     object_type = "Joker",
     order = 302,
@@ -31,55 +55,22 @@ local joker_png = {
 
         use_ability = function(self, card)
             ease_dollars(-card.ability.extra.cost)
-            local jokers = {}
-            for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-                if v.discovered and v.blueprint_compat and v.perishable_compat and v.rarity ~= 4 then
-                    if v.in_pool and type(v.in_pool) == 'function' then
-                        if v:in_pool() then
-                            jokers[#jokers+1] = v
-                        end
-                    else
-                        jokers[#jokers+1] = v
-                    end
-                end
-            end
-            local joker_center = pseudorandom_element(jokers, pseudoseed('joker_png'))
+
             for k,v in pairs(G.all_in_jest_joker_png.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest_joker_png == tostring(card) then
+                if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                     v:remove()
                 end
             end
-            SMODS.bypass_create_card_edition = true
-            local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
-            SMODS.bypass_create_card_edition = nil
-            G.all_in_jest_joker_png:emplace(joker)
-            joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-            joker.ability.all_in_jest_joker_png = tostring(card)
+
+            spawn_joker_png_joker(card)
+
             card:juice_up(0.3, 0.5)
             card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_reset')})
         end,
     },
 
     add_to_deck = function(self, card, from_debuff)
-        local jokers = {}
-        for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-            if v.discovered and v.blueprint_compat and v.rarity ~= 4 then
-                if v.in_pool and type(v.in_pool) == 'function' then
-                    if v:in_pool() then
-                        jokers[#jokers+1] = v
-                    end
-                else
-                    jokers[#jokers+1] = v
-                end
-            end
-        end
-        local joker_center = pseudorandom_element(jokers, pseudoseed('joker_png'))
-        SMODS.bypass_create_card_edition = true
-        local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
-        SMODS.bypass_create_card_edition = nil
-        G.all_in_jest_joker_png:emplace(joker)
-        joker.ability.all_in_jest = joker.ability.all_in_jest or {}
-        joker.ability.all_in_jest_joker_png = tostring(card)
+        spawn_joker_png_joker(card)
     end,
 
     update = function(self, card, dt)
@@ -89,9 +80,9 @@ local joker_png = {
     end,
   
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest_joker_png then
+        if G.all_in_jest_joker_png then
             for k,v in pairs(G.all_in_jest_joker_png.cards) do
-                if v.ability.all_in_jest and v.ability.all_in_jest_joker_png == tostring(card) then
+                if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                     local other_joker = v
                     info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
                 end
@@ -109,7 +100,7 @@ local joker_png = {
   
     calculate = function(self, card, context)
         for k,v in pairs(G.all_in_jest_joker_png.cards) do
-            if v.ability.all_in_jest and v.ability.all_in_jest_joker_png == tostring(card) then
+            if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                 local other_joker = v
                 return SMODS.blueprint_effect(card, other_joker, context)
             end

--- a/Items/Jokers/joker_png.lua
+++ b/Items/Jokers/joker_png.lua
@@ -1,25 +1,21 @@
 local spawn_joker_png_joker = function (card)
     local jokers = {}
-    for k,v in pairs(G.P_CENTER_POOLS["Joker"]) do
-        if v.discovered and v.blueprint_compat and v.perishable_compat and v.rarity ~= 4 and not G.GAME.banned_keys[v.key] then
-            if v.in_pool and type(v.in_pool) == 'function' then
-                if v:in_pool() then
-                    jokers[#jokers+1] = v
-                end
-            else
-                jokers[#jokers+1] = v
-            end
+    for _,v in pairs(G.P_CENTER_POOLS["Joker"]) do
+        if v.key ~= "j_aij_joker_png" and All_in_Jest.expanded_copier_compat(v, true) then
+            jokers[#jokers+1] = v
         end
     end
     local joker_center, index = pseudorandom_element(jokers, pseudoseed('joker_png'))
-    sendDebugMessage(joker_center.key, "AIJ")
-    sendDebugMessage(index, "AIJ")
     SMODS.bypass_create_card_edition = true
     local joker = create_card('Joker', G.all_in_jest_joker_png, nil, nil, true, nil, joker_center.key, 'joker_png')
     SMODS.bypass_create_card_edition = nil
     G.all_in_jest_joker_png:emplace(joker)
     joker.ability.all_in_jest = joker.ability.all_in_jest or {}
     joker.ability.all_in_jest.joker_png = card.unique_val
+
+    -- Useful debugging
+    -- sendDebugMessage(index, "AIJ")
+    -- sendDebugMessage(joker_center.key, "AIJ")
 end
 
 local joker_png = {
@@ -56,7 +52,7 @@ local joker_png = {
         use_ability = function(self, card)
             ease_dollars(-card.ability.extra.cost)
 
-            for k,v in pairs(G.all_in_jest_joker_png.cards) do
+            for _,v in pairs(G.all_in_jest_joker_png.cards) do
                 if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                     v:remove()
                 end
@@ -81,7 +77,7 @@ local joker_png = {
   
     loc_vars = function(self, info_queue, card)
         if G.all_in_jest_joker_png then
-            for k,v in pairs(G.all_in_jest_joker_png.cards) do
+            for _,v in pairs(G.all_in_jest_joker_png.cards) do
                 if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                     local other_joker = v
                     local other_vars = nil
@@ -112,7 +108,7 @@ local joker_png = {
     end,
   
     calculate = function(self, card, context)
-        for k,v in pairs(G.all_in_jest_joker_png.cards) do
+        for _,v in pairs(G.all_in_jest_joker_png.cards) do
             if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                 local other_joker = v
                 return SMODS.blueprint_effect(card, other_joker, context)

--- a/Items/Jokers/joker_png.lua
+++ b/Items/Jokers/joker_png.lua
@@ -37,7 +37,7 @@ local joker_png = {
     cost = 4,
     unlocked = true,
     discovered = false,
-    blueprint_compat = false,
+    blueprint_compat = true,
     eternal_compat = true,
 
     pixel_size = { w = 31, h = 40 },

--- a/Items/Jokers/joker_png.lua
+++ b/Items/Jokers/joker_png.lua
@@ -84,7 +84,20 @@ local joker_png = {
             for k,v in pairs(G.all_in_jest_joker_png.cards) do
                 if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == card.unique_val then
                     local other_joker = v
-                    info_queue[#info_queue + 1] = G.P_CENTERS[other_joker.config.center.key]
+                    local other_vars = nil
+                    if other_joker.config.center.loc_vars then
+                        local ret = other_joker.config.center:loc_vars({}, other_joker)
+                        if ret then
+                            other_vars = ret.vars
+                        end
+                    else
+                        other_vars, _, _ = other_joker:generate_UIBox_ability_table(true)
+                    end
+                    if other_vars then
+                        other_joker.config.center.specific_vars = other_vars
+                        other_joker.config.center.specific_vars.aij_joker_png = other_joker
+                    end
+                    info_queue[#info_queue + 1] = other_joker.config.center
                 end
             end
         end

--- a/Items/Jokers/opening_move.lua
+++ b/Items/Jokers/opening_move.lua
@@ -16,6 +16,7 @@ local opening_move = {
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
+    perishable_compat = false,
   
     loc_vars = function(self, info_queue, card)
         return {

--- a/Items/Jokers/paper_bag.lua
+++ b/Items/Jokers/paper_bag.lua
@@ -17,6 +17,7 @@ local paper_bag = {
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
+    perishable_compat = false,
   
     loc_vars = function(self, info_queue, card)
         return {

--- a/Items/Jokers/stock_broker.lua
+++ b/Items/Jokers/stock_broker.lua
@@ -14,7 +14,7 @@ local stock_broker = {
     cost = 6,
     unlocked = true,
     discovered = false,
-    blueprint_compat = true,
+    blueprint_compat = false,
     eternal_compat = true,
   
     loc_vars = function(self, info_queue, card)

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -18,7 +18,7 @@ local visage = {
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest_visage_last_sold and G.all_in_jest_visage_last_sold.cards[1] then
+        if G.all_in_jest_visage_last_sold and G.all_in_jest_visage_last_sold.cards[1] then
             local other_joker = G.all_in_jest_visage_last_sold.cards[1]
             local other_vars = nil
             if other_joker.config.center.loc_vars then
@@ -39,7 +39,7 @@ local visage = {
     end,
 
     calculate = function(self, card, context)
-        if G.all_in_jest and G.all_in_jest_visage_last_sold and G.all_in_jest_visage_last_sold.cards[1] then
+        if G.all_in_jest_visage_last_sold and G.all_in_jest_visage_last_sold.cards[1] then
             local other_joker = G.all_in_jest_visage_last_sold.cards[1]
             return SMODS.blueprint_effect(card, other_joker, context)
         end

--- a/Items/Jokers/visage.lua
+++ b/Items/Jokers/visage.lua
@@ -18,8 +18,8 @@ local visage = {
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)
-        if G.all_in_jest and G.all_in_jest.visage_last_sold and G.all_in_jest.visage_last_sold.cards[1] then
-            local other_joker = G.all_in_jest.visage_last_sold.cards[1]
+        if G.all_in_jest and G.all_in_jest_visage_last_sold and G.all_in_jest_visage_last_sold.cards[1] then
+            local other_joker = G.all_in_jest_visage_last_sold.cards[1]
             local other_vars = nil
             if other_joker.config.center.loc_vars then
                 local ret = other_joker.config.center:loc_vars({}, other_joker)
@@ -39,8 +39,8 @@ local visage = {
     end,
 
     calculate = function(self, card, context)
-        if G.all_in_jest and G.all_in_jest.visage_last_sold and G.all_in_jest.visage_last_sold.cards[1] then
-            local other_joker = G.all_in_jest.visage_last_sold.cards[1]
+        if G.all_in_jest and G.all_in_jest_visage_last_sold and G.all_in_jest_visage_last_sold.cards[1] then
+            local other_joker = G.all_in_jest_visage_last_sold.cards[1]
             return SMODS.blueprint_effect(card, other_joker, context)
         end
     end
@@ -50,10 +50,10 @@ local sell_card_ref = Card.sell_card
 function Card:sell_card()
     local ref = sell_card_ref(self)
     if G.jokers and self.ability.set == 'Joker' then
-        G.all_in_jest.visage_last_sold.cards = {}
+        G.all_in_jest_visage_last_sold.cards = {}
         if not (self.ability.name == 'j_aij_visage' or self.ability.name == 'j_aij_clay_joker') then
             local copied_card = copy_card(self, nil, 0) -- Creates a copy with 0 scale
-            G.all_in_jest.visage_last_sold:emplace(copied_card)
+            G.all_in_jest_visage_last_sold:emplace(copied_card)
         end
     end
     return ref

--- a/Items/Jokers/whiteface_grotesque.lua
+++ b/Items/Jokers/whiteface_grotesque.lua
@@ -17,6 +17,7 @@ local whiteface_grotesque = {
     discovered = false,
     blueprint_compat = true,
     eternal_compat = true,
+    perishable_compat = false,
   
     loc_vars = function(self, info_queue, card)
         return {

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -2681,4 +2681,6 @@ match_indent = true
 payload = '''
 if target.vars.aij_visage then card = G.all_in_jest_visage_last_sold.cards[1]; target.vars.aij_visage = nil end -- All in Jest
 if target.vars.aij_clay then card = G.all_in_jest_clay_last_destroyed.cards[1]; target.vars.aij_clay = nil end -- All in Jest
+if target.vars.aij_joker_png then card = target.vars.aij_joker_png; target.vars.aij_joker_png = nil end -- All in Jest
+if target.vars.aij_czar then card = target.vars.aij_czar; target.vars.aij_czar = nil end -- All in Jest
 '''

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -1325,8 +1325,24 @@ if self.ability.name == 'j_aij_clay_joker' or self.ability.name == 'j_aij_visage
         other_joker = G.all_in_jest_visage_last_sold.cards[1]
     elseif self.ability.name == 'j_aij_clay_joker' then
         other_joker = G.all_in_jest_clay_last_destroyed.cards[1]
+    elseif self.ability.name == 'j_aij_joker_png' then
+        for _,v in pairs(G.all_in_jest_joker_png.cards) do
+            if v.ability.all_in_jest and v.ability.all_in_jest.joker_png == self.unique_val then
+                other_joker = v
+                break
+            end
+        end
+    elseif self.ability.name == 'j_aij_czar' then
+        for _,v in pairs(G.all_in_jest_czar.cards) do
+            if v.ability.all_in_jest and v.ability.all_in_jest.czar == self.unique_val then
+                other_joker = v
+                break
+            end
+        end
     end
-    if (other_joker and other_joker ~= self and other_joker.config and other_joker.config.center.blueprint_compat) or (self.ability.name == 'j_aij_czar' or self.ability.name == 'j_aij_joker_png') then
+    if 
+        other_joker and other_joker ~= self and other_joker.config and All_in_Jest.expanded_copier_compat(other_joker.config.center, (self.ability.name == 'j_aij_czar' or self.ability.name == 'j_aij_joker_png'))
+    then
         self.ability.blueprint_compat = 'compatible'
     else
         self.ability.blueprint_compat = 'incompatible'

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -1312,7 +1312,7 @@ payload = '''
 elseif _type == 'Joker' and next(SMODS.find_card("j_aij_little_boy_blue")) then _pool[#_pool + 1] = "j_aij_simple_simon"
 '''
 
-# Clay Joker and Visage Comapat visuals
+# Copy joker Comapat visuals
 [[patches]]
 [patches.pattern]
 target = "card.lua"

--- a/Lovely/lovely.toml
+++ b/Lovely/lovely.toml
@@ -1322,9 +1322,9 @@ payload = '''
 if self.ability.name == 'j_aij_clay_joker' or self.ability.name == 'j_aij_visage' or (self.ability.name == 'j_aij_czar' or self.ability.name == 'j_aij_joker_png') then
 	local other_joker = nil
     if self.ability.name == 'j_aij_visage' then
-        other_joker = G.all_in_jest.visage_last_sold.cards[1]
+        other_joker = G.all_in_jest_visage_last_sold.cards[1]
     elseif self.ability.name == 'j_aij_clay_joker' then
-        other_joker = G.all_in_jest.clay_last_destroyed.cards[1]
+        other_joker = G.all_in_jest_clay_last_destroyed.cards[1]
     end
     if (other_joker and other_joker ~= self and other_joker.config and other_joker.config.center.blueprint_compat) or (self.ability.name == 'j_aij_czar' or self.ability.name == 'j_aij_joker_png') then
         self.ability.blueprint_compat = 'compatible'
@@ -2642,19 +2642,19 @@ G.all_in_jest.patches_sprites["Diamonds"] = Sprite(0,0,G.CARD_W,G.CARD_H,G.ASSET
 G.all_in_jest.patches_sprites["Spades"] = Sprite(0,0,G.CARD_W,G.CARD_H,G.ASSET_ATLAS["aij_enhancements_atlas"], {x=4,y=2})
 G.all_in_jest.patches_sprites["paperback_Stars"] = Sprite(0,0,G.CARD_W,G.CARD_H,G.ASSET_ATLAS["aij_enhancements_atlas"], {x=5,y=2})
 G.all_in_jest.patches_sprites["paperback_Crowns"] = Sprite(0,0,G.CARD_W,G.CARD_H,G.ASSET_ATLAS["aij_enhancements_atlas"], {x=6,y=2})
-self.all_in_jest.czar = CardArea(
+self.all_in_jest_czar = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 99999999, type = 'joker'})
-self.all_in_jest.joker_png = CardArea(
+self.all_in_jest_joker_png = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 99999999, type = 'joker'})
-self.all_in_jest.clay_last_destroyed = CardArea(
+self.all_in_jest_clay_last_destroyed = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 1, type = 'joker'})
-self.all_in_jest.visage_last_sold = CardArea(
+self.all_in_jest_visage_last_sold = CardArea(
         -10, -10,
         CAI.discard_W,CAI.discard_H,
         {card_limit = 1, type = 'joker'})
@@ -2679,6 +2679,6 @@ pattern = "if target.vars.is_info_queue then target.is_info_queue = true; target
 position = "after"
 match_indent = true
 payload = '''
-if target.vars.aij_visage then card = G.all_in_jest.visage_last_sold.cards[1]; target.vars.aij_visage = nil end -- All in Jest
-if target.vars.aij_clay then card = G.all_in_jest.clay_last_destroyed.cards[1]; target.vars.aij_clay = nil end -- All in Jest
+if target.vars.aij_visage then card = G.all_in_jest_visage_last_sold.cards[1]; target.vars.aij_visage = nil end -- All in Jest
+if target.vars.aij_clay then card = G.all_in_jest_clay_last_destroyed.cards[1]; target.vars.aij_clay = nil end -- All in Jest
 '''

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -1513,20 +1513,23 @@ function All_in_Jest.reset_game_globals(run_start)
     end
 end
 
--- Set from_base to true for jokers that copy a joker from collection and therefore has their base values
-function All_in_Jest.expanded_copier_compat(center, from_base)
+-- Function to allow for filtering joker-copy effects and applying blacklists to copiable jokers
+-- Used by: Visage, Clay Joker, Joker.png, and Czar
+--  from_collection - set true for jokers that copy a joker from collection, rather than a joker that was previously in-play
+function All_in_Jest.expanded_copier_compat(center, from_collection)
     if not (center and type(center) == "table") then
         return
     end
     local blacklist = {
-        'j_blueprint'
+        'j_blueprint',
+        'j_aij_lexicon' -- Crashes the game for some reason, temporary fix
     }
-    if from_base then
+    if from_collection then
         table.insert(blacklist, 'j_campfire')
     end
 
     if center.blueprint_compat and 
-        (not from_base or (center.discovered and 
+        (not from_collection or (center.discovered and 
         center.perishable_compat and 
         center.rarity ~= 4 and 
         not G.GAME.banned_keys[center.key]))
@@ -1536,9 +1539,28 @@ function All_in_Jest.expanded_copier_compat(center, from_base)
                 return false
             end
         end
-        if center.in_pool and type(center.in_pool) == 'function' then
-            return center:in_pool()
-        end
+
+        -- if from_collection then
+        --     if center.in_pool and type(center.in_pool) == 'function' then
+        --         return center:in_pool()
+        --     end
+
+        --     if center.yes_pool_flag and not G.GAME.pool_flags[center.yes_pool_flag] then
+        --         return false
+        --     end
+        --     if center.no_pool_flag and G.GAME.pool_flags[center.no_pool_flag] then
+        --         return false
+        --     end
+
+        --     if center.enhancement_gate then
+        --         for _, v in pairs(G.playing_cards) do
+        --             if SMODS.has_enhancement(v, center.enhancement_gate) then
+        --                 return true
+        --             end
+        --         end
+        --     end
+        -- end
+
         return true
     else
         return false

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -1512,3 +1512,35 @@ function All_in_Jest.reset_game_globals(run_start)
         G.all_in_jest.pit_blind_ante = pseudorandom_element(index, pseudoseed('pit_blinds'))
     end
 end
+
+-- Set from_base to true for jokers that copy a joker from collection and therefore has their base values
+function All_in_Jest.expanded_copier_compat(center, from_base)
+    if not (center and type(center) == "table") then
+        return
+    end
+    local blacklist = {
+        'j_blueprint'
+    }
+    if from_base then
+        table.insert(blacklist, 'j_campfire')
+    end
+
+    if center.blueprint_compat and 
+        (not from_base or (center.discovered and 
+        center.perishable_compat and 
+        center.rarity ~= 4 and 
+        not G.GAME.banned_keys[center.key]))
+    then
+        for _, v in ipairs(blacklist) do
+            if center.key == v then
+                return false
+            end
+        end
+        if center.in_pool and type(center.in_pool) == 'function' then
+            return center:in_pool()
+        end
+        return true
+    else
+        return false
+    end
+end

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -1526,6 +1526,11 @@ function All_in_Jest.expanded_copier_compat(center, from_collection)
     }
     if from_collection then
         table.insert(blacklist, 'j_campfire')
+
+        -- can remove these if they are made un-perishable
+        table.insert(blacklist, 'j_aij_egg_cc')
+        table.insert(blacklist, 'j_aij_toothy_joker')
+        table.insert(blacklist, 'j_aij_coulrorachne')
     end
 
     if center.blueprint_compat and 


### PR DESCRIPTION
The save game function only checks for card areas that are direct children of G, so any card areas in G.all_in_jest get skipped. 
One way to fix this is to modify the save_run() and start_run() to check this, but it is much easier to move these Card areas to be direct children, which is what this PR does:
- G.all_in_jest.czar -> G.all_in_jest_czar
- G.all_in_jest.joker_png -> G.all_in_jest_joker_png
- G.all_in_jest.clay_last_destroyed -> G.all_in_jest_clay_last_destroyed
- G.all_in_jest.visage_last_sold -> G.all_in_jest_visage_last_sold