### PR TITLE
Remove blueprint compat from croupier

### DIFF
--- a/Items/Jokers/croupier.lua
+++ b/Items/Jokers/croupier.lua
@@ -14,7 +14,7 @@ local croupier = {
     cost = 4,
     unlocked = true,
     discovered = false,
-    blueprint_compat = true,
+    blueprint_compat = false,
     eternal_compat = true,
 
     loc_vars = function(self, info_queue, card)


### PR DESCRIPTION
Croupier has a set amount of money and is a cash out effect, so Blueprint effects don't do anything. This also causes Jokers like Joker.png to copy it erroneously.