### PR TITLE
Has dark_star and rogue_planet call SMODS.upgrade_poker_hands

### DIFF
--- a/Items/Consumables/Planets/dark_star.lua
+++ b/Items/Consumables/Planets/dark_star.lua
@@ -35,7 +35,7 @@ local dark_star = {
         table.insert(hands_to_upgrade, k)
       end
     end
-    level_up_hand(card, hands_to_upgrade)
+    SMODS.upgrade_poker_hands(hands_to_upgrade)
   end,
   in_pool = function(self, args)
     for _, k in ipairs(G.handlist) do

--- a/Items/Consumables/Planets/rogue_planet.lua
+++ b/Items/Consumables/Planets/rogue_planet.lua
@@ -66,7 +66,7 @@ local rogue_planet = {
         end
       end
     end
-    level_up_hand(card, hands_to_upgrade)
+    SMODS.upgrade_poker_hands(hands_to_upgrade)
   end,
   in_pool = function(self, args)
     if G.GAME and G.jokers then


### PR DESCRIPTION
Fix concerning [this issue](https://github.com/survovoaneend/All-In-Jest/issues/186), has dark_star and rogue_planet call SMODS.upgrade_poker_hands directly, as that is able to handle the new level up scoring hands API and be passed a table of hands instead of a string of a single hand