### PR TITLE
implement guess the jest accessibility config

### DIFF
--- a/Utils/ui.lua
+++ b/Utils/ui.lua
@@ -130,6 +130,17 @@ SMODS.current_mod.config_tab = function()
                     ref_value = 'random_deck_skins'
                   },
                 },
+              },
+              {
+                n = G.UIT.C,
+                config = {tooltip = {text = localize('aij_guess_names_tooltip')}},
+                nodes = {
+                  create_toggle {
+                    label = localize('aij_guess_names'),
+                    ref_table = All_in_Jest.config,
+                    ref_value = 'guess_names'
+                  },
+                },
               }
             }
           },

--- a/config.lua
+++ b/config.lua
@@ -6,4 +6,5 @@ return {
   ['random_deck_skins'] = true,
   ['red_destroy_text'] = true,
   ['aij_lite'] = false,
+  ['guess_names'] = false,
 }

--- a/localization/default.lua
+++ b/localization/default.lua
@@ -59,6 +59,13 @@ return {
                 '{C:attention}Playing cards{} added to the',
                 'deck have random {C:attention}deck skins'
             },
+            aij_guess_names = 'Guess the Jest Names',
+            aij_guess_names_tooltip = {
+                'Accessibility option for {C:purple}Guess',
+                '{C:purple}the Jest Packs{}, showing the',
+                'names of the Jokers',
+                '{s:0.8,C:inactive}(but not their descriptions)'
+            },
             k_aij_guess_the_jest = "Guess the Jest",
             k_aij_memory_card = "Memorized!", -- Memory Card, currently unused
             aij_plus_tag = "+1 Tag", -- Various jokers
@@ -4965,6 +4972,12 @@ return {
                     "{C:attention}unchanged{} when reversed",
                     "{C:inactive}ex. 33, 151, 3003{}"
                 }
+            },
+            guess_the_jest_hidden={
+                name="???",
+                text={
+                    "{C:inactive,E:1,s:1.5}???{}",
+                },
             },
             -- Stickers
             aij_marked = {

--- a/lovely/lovely.toml
+++ b/lovely/lovely.toml
@@ -2532,8 +2532,8 @@ if G.STATE == G.STATES.NEW_ROUND then
 end
 '''
 
-# Guess the Jest (1/2)
-# Prevents tooltip for Guess the Jest cards from appearing while hovering over cards in the pack
+# Guess the Jest (1/4)
+# Prevents tooltip for Guess the Jest cards from appearing while hovering over cards in the pack (if 'Guess the Jest Names' is not enabled)
 # Card:hover()
 [[patches]]
 [patches.pattern]
@@ -2543,12 +2543,45 @@ position = "before"
 match_indent = true
 payload = '''
 -- Prevent tooltip for Guess the Jest cards while in the pack
-if (self.ability and self.ability.from_guess_the_jest and self.area == G.pack_cards) or self.ability.jest_got_no_ui then
+if not All_in_Jest.config.guess_names and self.ability and self.ability.from_guess_the_jest and self.area == G.pack_cards then
+    return
+end
+if self.ability.jest_got_no_ui then
     return
 end
 '''
 
-# Guess the Jest (2/2)
+# Guess the Jest (2/4)
+# If 'Guess the Jest Names' is enabled, replace the card's description with '???'
+# SMODS.Center:generate_ui
+[[patches]]
+[patches.pattern]
+target = '=[SMODS _ "src/game_object.lua"]'
+pattern = "if specific_vars and specific_vars.debuffed and not res.replace_debuff then"
+position = "before"
+match_indent = true
+payload = '''
+if card.ability and card.ability.from_guess_the_jest then
+    target = { type = 'other', key = 'guess_the_jest_hidden', nodes = desc_nodes, AUT = full_UI_table, }
+end
+'''
+
+# Guess the Jest (3/4)
+# Clear info_queue if card is hidden
+# generate_card_ui
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "SMODS.compat_0_9_8.generate_UIBox_ability_table_card = nil"
+position = "after"
+match_indent = true
+payload = '''
+if card and card.ability and card.ability.from_guess_the_jest then
+    info_queue = {}
+end
+'''
+
+# Guess the Jest (4/4)
 # Remove from_guess_the_jest attribute once joker has been selected
 # Card:add_to_deck
 [[patches]]


### PR DESCRIPTION
adds a "Guess the Jest Names" config accesibility option, which will display the names of the jokers in the packs (still keeping their descriptions hidden). off by default