### PR TITLE
Update Balatro Multiplayer crossmod compat

### DIFF
--- a/Items/Crossmod/Multiplayer/mp_blind_drawn.lua
+++ b/Items/Crossmod/Multiplayer/mp_blind_drawn.lua
@@ -56,7 +56,7 @@ local mp_blind_drawn = {
     end,
 
     mp_include = function(self)
-		    return MP.UTILS.is_standard_ruleset() and MP.LOBBY.code
+		    return MP.is_layer_active("standard") and MP.LOBBY.code
     end,
   
 }

--- a/Items/Jokers/fall_of_count_chaligny.lua
+++ b/Items/Jokers/fall_of_count_chaligny.lua
@@ -14,7 +14,7 @@ local fall_of_count_chaligny = {
     eternal_compat = true,
   
     loc_vars = function(self, info_queue, card)
-        if MP and MP.UTILS.is_standard_ruleset() and MP.LOBBY.code then
+        if MP and MP.is_layer_active("standard") and MP.LOBBY.code then
             return {key = "j_aij_mp_fall_of_count_chaligny"}
         end
     end,


### PR DESCRIPTION
About two months ago, the multiplayer mod [removed `is_standard_ruleset` and replaced it with a new layered approach](https://github.com/Balatro-Multiplayer/BalatroMultiplayer/pull/396). This was released [in v0.4.0 on June 8, 2026](https://github.com/Balatro-Multiplayer/BalatroMultiplayer/releases/tag/v0.4.0/).

This PR updates the crossmod file and Fall of Count Chaligny to use the new function.