### PR TITLE
use pools for random effects more

### DIFF
--- a/Items/Blinds/Boss/the_elbow.lua
+++ b/Items/Blinds/Boss/the_elbow.lua
@@ -22,12 +22,8 @@ local the_elbow = {
             local triggers = 0
             for _, scored_card in ipairs(context.full_hand) do
                 if scored_card.config.center ~= G.P_CENTERS.c_base then
-                    local cen_pool = {}
-                    for _, v in ipairs(G.P_CENTER_POOLS["Enhanced"]) do
-                        cen_pool[#cen_pool+1] = v
-                    end
-                    center = pseudorandom_element(cen_pool, pseudoseed('the_elbow'))
-                    scored_card:set_ability(center, nil, true)
+                    local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'the_elbow'})
+                    scored_card:set_ability(G.P_CENTERS[enhance], nil, true)
                     G.E_MANAGER:add_event(Event({
                         func = function()
                             scored_card:juice_up(0.3, 0.3)

--- a/Items/Consumables/Spectrals/palmistry.lua
+++ b/Items/Consumables/Spectrals/palmistry.lua
@@ -33,12 +33,8 @@ local palmistry = {
             G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.15,func = function() G.hand.cards[i]:flip();play_sound('card1', percent);G.hand.cards[i]:juice_up(0.3, 0.3);return true end }))
         end
         delay(0.2)
-        local cen_pool = {}
-        for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-            cen_pool[#cen_pool+1] = v
-        end
         for k, v in ipairs(G.hand.cards) do
-            local enhance = pseudorandom_element(cen_pool, pseudoseed('palmistry'..G.GAME.round_resets.ante)).key
+            local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'palmistry'..G.GAME.round_resets.ante})
             G.E_MANAGER:add_event(Event({func = function()
                 v:set_ability(G.P_CENTERS[enhance])
             return true end }))

--- a/Items/Consumables/Tarots/Hex/oracle.lua
+++ b/Items/Consumables/Tarots/Hex/oracle.lua
@@ -34,11 +34,7 @@ local oracle = {
             G.E_MANAGER:add_event(Event({trigger = 'after',delay = 0.15,func = function() G.hand.cards[i]:flip();play_sound('card1', percent);G.hand.cards[i]:juice_up(0.3, 0.3);return true end }))
         end
         delay(0.2)
-        local cen_pool = {}
-        for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-            cen_pool[#cen_pool+1] = v
-        end
-        local enhance = pseudorandom_element(cen_pool, pseudoseed('oracle'..G.GAME.round_resets.ante)).key
+        local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'oracle'..G.GAME.round_resets.ante})
         for k, v in ipairs(G.hand.cards) do
             G.E_MANAGER:add_event(Event({func = function()
                 v:set_ability(G.P_CENTERS[enhance])

--- a/Items/Consumables/Tarots/Other/golem.lua
+++ b/Items/Consumables/Tarots/Other/golem.lua
@@ -60,9 +60,9 @@ local golem = {
 		delay(0.2)
 
 		local cen_pool = {}
-		for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
+		for k, v in pairs(get_current_pool("Enhanced")) do
 			if v.key ~= "m_stone" then
-				cen_pool[#cen_pool + 1] = v.key
+				cen_pool[#cen_pool + 1] = v
 			end
 		end
 		for i = 1, #G.hand.highlighted do
@@ -70,8 +70,8 @@ local golem = {
 				trigger = "after",
 				delay = 0.1,
 				func = function()
-					center = pseudorandom_element(cen_pool, pseudoseed("golem"))
-					All_in_Jest.set_other_enhancement(G.hand.highlighted[i], center)
+					local enhance = SMODS.poll_enhancement({guaranteed = true, options = cen_pool, key = 'golem'})
+					All_in_Jest.set_other_enhancement(G.hand.highlighted[i], enhance)
 					return true
 				end,
 			}))

--- a/Items/Consumables/Tarots/sacrifice.lua
+++ b/Items/Consumables/Tarots/sacrifice.lua
@@ -26,15 +26,11 @@ local sacrifice = {
         SMODS.destroy_cards(destroy_card, nil, true)
         G.E_MANAGER:add_event(Event({
             func = function()
-				local cen_pool = {}
-                for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-                    if v.key ~= 'm_stone' then 
-                        cen_pool[#cen_pool+1] = v
-                    end
-                end
+                local front = pseudorandom_element(G.P_CARDS, pseudoseed('sacrifice'))
+                local enhance = SMODS.poll_enhancement({guaranteed = true, no_replace = true, key = 'sacrifice'})
                 local _card = create_playing_card({
-                    front = pseudorandom_element(G.P_CARDS, pseudoseed('sacrifice')),
-                    center = pseudorandom_element(cen_pool, pseudoseed('sacrifice'))}, G.hand, nil, nil, {G.C.SECONDARY_SET.Enhanced})
+                    front = front,
+                    center = G.P_CENTERS[enhance]}, G.hand, nil, nil, {G.C.SECONDARY_SET.Enhanced})
                 G.GAME.blind:debuff_card(_card)
                 G.hand:sort()
                 playing_card_joker_effects({_card})

--- a/Items/Jokers/crop_circle.lua
+++ b/Items/Jokers/crop_circle.lua
@@ -28,16 +28,12 @@ local crop_circle = {
         if context.using_consumeable then
             if context.consumeable.ability.set == 'Planet' then
                 for i = 1, card.ability.extra.cards do
-                    local cen_pool = {}
-                    for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-                        cen_pool[#cen_pool+1] = v
-                    end
-                    center = pseudorandom_element(cen_pool, pseudoseed('crop_circle'..i))
+                    local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'crop_circle'..i})
                     if G.hand and #G.hand.cards > 0 then
                         local ran_card = pseudorandom_element(G.hand.cards, pseudoseed('crop_circle'..i))
                         play_sound('card1', 0.9 + i*0.05, 0.5) 
                         ran_card:juice_up(0.2, 0.1)
-                        ran_card:set_ability(center)
+                        ran_card:set_ability(G.P_CENTERS[enhance])
                         local juice_card = context.blueprint_card or card
                         juice_card:juice_up(0.5, 0.2)
                     end

--- a/Items/Jokers/doormat.lua
+++ b/Items/Jokers/doormat.lua
@@ -27,14 +27,10 @@ local doormat = {
     calculate = function(self, card, context)
         if context.first_hand_drawn and #SMODS.drawn_cards > 0 then
             local cur_card = SMODS.drawn_cards[1]
-            local cen_pool = {}
-            for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-                cen_pool[#cen_pool+1] = v
-            end
-            center = pseudorandom_element(cen_pool, pseudoseed('doormat'))
+            local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'doormat'})
             play_sound('card1', 0.9 + 0.05, 0.5) 
             cur_card:juice_up(0.2, 0.1)
-            cur_card:set_ability(center)
+            cur_card:set_ability(G.P_CENTERS[enhance])
             card:juice_up(0.5, 0.2)
         end
     end

--- a/Items/Jokers/rummikub.lua
+++ b/Items/Jokers/rummikub.lua
@@ -44,9 +44,10 @@ function create_UIBox_rummikub()
   local ranks_option_cycle = create_option_cycle({label = "Set Rank", text_scale = 0.4, scale = 0.8, w = 3, options = rank_pool, opt_callback = "tag_aij_nonstandard_set_rank", current_option = 1})
 
   local enhancement_pool = {localize("k_none")}
-  for _, enhancement in pairs(G.P_CENTER_POOLS.Enhanced) do
-      local enhancement_key = enhancement.key
-      table.insert(enhancement_pool, localize{key = enhancement_key, set = "Enhanced", type = "name_text"})
+  for _, enhancement in pairs(get_current_pool("Enhanced")) do
+    if enhancement ~= "UNAVAILABLE" then
+      table.insert(enhancement_pool, localize{key = enhancement, set = "Enhanced", type = "name_text"})
+    end
   end
   local enhancements_option_cycle = create_option_cycle({label = "Enhancement", text_scale = 0.4, scale = 0.8, w = 3, options = enhancement_pool, opt_callback = "tag_aij_nonstandard_set_enhancement", current_option = 1})
 

--- a/Items/Other/chaotic.lua
+++ b/Items/Other/chaotic.lua
@@ -37,15 +37,11 @@ local chaotic_card = {
                     trigger = 'after',
                     delay = 0.1,
                     func = function()
-                        local cen_pool = {}
-                        for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-                            cen_pool[#cen_pool+1] = v
-                        end
-                        center = pseudorandom_element(cen_pool, pseudoseed('jest_chaotic_card'))
+                        local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'jest_chaotic_card'})
                         play_sound('tarot2')
                     
                         card:juice_up(0.3, 0.3)
-                        card:set_ability(center)
+                        card:set_ability(G.P_CENTERS[enhance])
                         return true
                     end
                 }))

--- a/Items/Tag/Gold/anarchy.lua
+++ b/Items/Tag/Gold/anarchy.lua
@@ -80,12 +80,12 @@ local anarchy_tag = {
             local bosses = {}
             local showdown_bosses = {}
             for k, v in pairs(G.P_BLINDS) do
-              if v and v.boss and v.boss.showdown then
+              if v and v.boss and v.boss.showdown and SMODS.add_to_pool(v) and not G.GAME.banned_keys[k] then
                 table.insert(showdown_bosses, v)
               end
             end
             for k, v in pairs(G.P_BLINDS) do
-              if v and v.boss then
+              if v and v.boss and SMODS.add_to_pool(v) and not G.GAME.banned_keys[k] then
                 table.insert(bosses, v)
                 if not v.boss.showdown then
                   local ran = pseudorandom('jest_chaos_tag', 1, #showdown_bosses)
@@ -124,13 +124,7 @@ local anarchy_tag = {
             G.blind_select_opts.boss.parent = par
             G.blind_select_opts.boss.alignment.offset.y = 0
           elseif effect == "open_booster" then
-            local boosters = {}
-            for k, v in pairs(G.P_CENTERS) do
-              if v.set == 'Booster' then
-                table.insert(boosters, k)
-              end
-            end
-            local key = boosters[pseudorandom('jest_chaos_tag', 1, #boosters)]
+            local key = get_pack('jest_chaos_tag').key
             local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2,
               G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2, G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty,
               G.P_CENTERS[key], { bypass_discovery_center = true, bypass_discovery_ui = true })
@@ -241,12 +235,7 @@ local anarchy_tag = {
               local cur_card = copy_card(temp_card)
 
               cur_card:set_base(new_card)
-              local cen_pool = {}
-              for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-                cen_pool[#cen_pool + 1] = v
-              end
-              local enhance = pseudorandom_element(cen_pool, pseudoseed('jest_anarchy_tag' .. G.GAME.round_resets.ante))
-              .key
+              local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'jest_anarchy_tag' .. G.GAME.round_resets.ante})
               cur_card:set_ability(G.P_CENTERS[enhance])
               cur_card:add_to_deck()
               G.deck:emplace(cur_card)
@@ -257,13 +246,9 @@ local anarchy_tag = {
             temp_card:start_dissolve()
           elseif effect == "give_ran_enhance" then
             local cur_ran = pseudorandom('jest_anarchy_tag', 3, 8)
-            local cen_pool = {}
-            for k, v in pairs(G.P_CENTER_POOLS["Enhanced"]) do
-              cen_pool[#cen_pool + 1] = v
-            end
             for i = 1, cur_ran do
               local deck_cards = {}
-              local enhance = pseudorandom_element(cen_pool, pseudoseed('jest_anarchy_tag' .. G.GAME.round_resets.ante)) .key
+              local enhance = SMODS.poll_enhancement({guaranteed = true, key = 'jest_anarchy_tag' .. G.GAME.round_resets.ante})
               for i = 1, #G.deck.cards do
                 table.insert(deck_cards, G.deck.cards[i])
               end

--- a/Items/Tag/chaos.lua
+++ b/Items/Tag/chaos.lua
@@ -57,7 +57,7 @@ local chaos = {
           elseif effect == "boss_reroll" and not (MP and MP.LOBBY.code) then
             local bosses = {}
             for k, v in pairs(G.P_BLINDS) do
-              if v and v.boss then
+              if v and v.boss and SMODS.add_to_pool(v) and not G.GAME.banned_keys[k] then
                 table.insert(bosses, v)
               end
             end
@@ -93,13 +93,7 @@ local chaos = {
             G.blind_select_opts.boss.alignment.offset.y = 0
             play_sound('other1')
           elseif effect == "open_booster" then
-            local boosters = {}
-            for k, v in pairs(G.P_CENTERS) do
-              if v.set == 'Booster' then
-                table.insert(boosters, k)
-              end
-            end
-            local key = boosters[pseudorandom('jest_chaos_tag', 1, #boosters)]
+            local key = get_pack('jest_chaos_tag').key
             local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2,
               G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2, G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty,
               G.P_CENTERS[key], { bypass_discovery_center = true, bypass_discovery_ui = true })

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -1737,10 +1737,9 @@ end
 function reset_jest_you_broke_it_card()
   G.GAME.current_round.jest_you_broke_it_card.rank = 'Ace'
   G.GAME.current_round.jest_you_broke_it_card.enhancement = 'm_bonus'
-  local valid_enhancements = get_current_pool("Enhanced")
   local valid_jest_ybi_cards = {}
     for k, v in ipairs(G.playing_cards) do
-        if v.ability.effect ~= 'Stone Card' then
+        if not SMODS.has_no_rank(v) then
             valid_jest_ybi_cards[#valid_jest_ybi_cards+1] = v
         end
     end
@@ -1749,29 +1748,12 @@ function reset_jest_you_broke_it_card()
         G.GAME.current_round.jest_you_broke_it_card.rank = jest_ybi_card.base.value
         G.GAME.current_round.jest_you_broke_it_card.id = jest_ybi_card.base.id
     end
-    if valid_enhancements[1] then
-      local jest_ybi_enhancement = pseudorandom_element(valid_enhancements, pseudoseed('ybi'..G.GAME.round_resets.ante))
-      local it = 1
-      while jest_ybi_enhancement == 'UNAVAILABLE' do
-        it = it + 1
-        jest_ybi_enhancement = pseudorandom_element(valid_enhancements, pseudoseed('ybi'..'_resample'..it))
-      end
-      G.GAME.current_round.jest_you_broke_it_card.enhancement = jest_ybi_enhancement
-    end
+    G.GAME.current_round.jest_you_broke_it_card.enhancement = SMODS.poll_enhancement({guaranteed = true, key = 'ybi'..G.GAME.round_resets.ante})
 end
 function reset_handsome_joker_card()
   G.GAME.current_round.jest_handsome_joker_card.rank = 'Ace'
   G.GAME.current_round.jest_handsome_joker_card.suit = 'Spades'
   G.GAME.current_round.jest_handsome_joker_card.enhancement = 'm_bonus'
-  local all_enhancements = get_current_pool("Enhanced")
-  local valid_enhancements = {}
-
-  -- Loop through the original list of all enhancements
-  for _, enhancement in ipairs(all_enhancements) do
-    if enhancement ~= "UNAVAILABLE" and not (enhancement == 'm_stone' or enhancement == 'm_aij_canvas' or G.P_CENTERS[enhancement].no_rank or G.P_CENTERS[enhancement].no_suit) then
-      valid_enhancements[#valid_enhancements + 1] = enhancement
-    end
-  end
   local valid_jest_handsome_cards = {}
     for k, v in ipairs(G.playing_cards) do
         local enhancement = v.ability.effect
@@ -1785,15 +1767,7 @@ function reset_handsome_joker_card()
         G.GAME.current_round.jest_handsome_joker_card.rank = jest_handsome_card.base.value
         G.GAME.current_round.jest_handsome_joker_card.id = jest_handsome_card.base.id
     end
-    if valid_enhancements[1] then
-      local jest_handsome_card_enhancement = pseudorandom_element(valid_enhancements, pseudoseed('handsome'..G.GAME.round_resets.ante))
-      local it = 1
-      while jest_handsome_card_enhancement == 'UNAVAILABLE' do
-        it = it + 1
-        jest_handsome_card_enhancement = pseudorandom_element(valid_enhancements, pseudoseed('handsome'..'_resample'..it))
-      end
-      G.GAME.current_round.jest_handsome_joker_card.enhancement = jest_handsome_card_enhancement
-    end
+    G.GAME.current_round.jest_handsome_joker_card.enhancement = SMODS.poll_enhancement({guaranteed = true, no_replace = true, key = 'handsome'..G.GAME.round_resets.ante})
 end
 function reset_the_auroch_blind()
     local common_suit, common_rank = nil, nil


### PR DESCRIPTION
primarily, this replaces all instances of manually constructing a pool of enhancements with `SMODS.poll_enhancement`, which makes it more compatible with other mods. this shouldn't impact how the RNG works at all

some similar changes were also made to the Anarchy and Chaos tags for the boss reroll and booster pack effects, to ensure they also only received options that should be in the pool normally