### PR TITLE
some fixes for astral cards

### DIFF
--- a/Items/Consumables/Astrals/alcyone.lua
+++ b/Items/Consumables/Astrals/alcyone.lua
@@ -61,7 +61,7 @@ local alcyone_pin = {
             G.E_MANAGER:add_event(Event({
                 trigger = 'after',
                 func = function()
-                    SMODS.destroy_cards(card, true)
+                    card:start_dissolve()
                     return true
             end}))
             return {

--- a/Utils/functions.lua
+++ b/Utils/functions.lua
@@ -2181,11 +2181,6 @@ function All_in_Jest.use_astral_card(card)
             end
         end
         if G.GAME.Astral_pins then
-            All_in_Jest.old_colours = All_in_Jest.old_colours or {
-                special_colour = copy_table(G.C.BACKGROUND.C),
-                tertiary_colour = copy_table(G.C.BACKGROUND.D),
-                new_colour = copy_table(G.C.BACKGROUND.L),
-            }
             All_in_Jest.astral_visuals(card.ability.consumeable.hand, 'no_remove')       
         end
         G.E_MANAGER:add_event(Event({
@@ -2276,7 +2271,7 @@ function All_in_Jest.astral_background(type, colours)
             end
         }))
     else
-        ease_background_colour({special_colour = colours.background[1], tertiary_colour = colours.background[2], new_colour = colours.background[3]})
+        ease_background_colour({special_colour = colours.background[1], tertiary_colour = colours.background[2], new_colour = colours.background[3], contrast = colours.background[4]})
         if G.aij_astral_stars then G.aij_astral_stars:fade(0.25) end
         if G.aij_astral_meteors then G.aij_astral_meteors:fade(0.25) end
 
@@ -2296,6 +2291,7 @@ function All_in_Jest.astral_visuals(hand, extra, old_colours, immediate, colours
         special_colour = copy_table(G.C.BACKGROUND.C),
         tertiary_colour = copy_table(G.C.BACKGROUND.D),
         new_colour = copy_table(G.C.BACKGROUND.L),
+        contrast = 1,
     }
     colours = colours or {}
     if extra == 'only_color' then
@@ -2304,11 +2300,11 @@ function All_in_Jest.astral_visuals(hand, extra, old_colours, immediate, colours
                 trigger = 'after',
                 delay = 1,
                 func = function()
-                    All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour}})
+                    All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour, old_colours.contrast}})
                     return true
             end}))
         else
-            All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour}})
+            All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour, old_colours.contrast}})
         end
         return
     end
@@ -2321,8 +2317,7 @@ function All_in_Jest.astral_visuals(hand, extra, old_colours, immediate, colours
             end
         end
         if astrals == 0 then
-            All_in_Jest.astral_visuals(hand, 'only_remove', All_in_Jest.old_colours or old_colours, true)  
-            All_in_Jest.old_colours = nil
+            All_in_Jest.astral_visuals(hand, 'only_remove', All_in_Jest.old_colours or old_colours, true)
             return
         end
         if G.GAME.Astral_pins[hand] then
@@ -2357,7 +2352,7 @@ function All_in_Jest.astral_visuals(hand, extra, old_colours, immediate, colours
                 trigger = 'after',
                 delay = 1,
                 func = function()
-                    All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour}})
+                    All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour, old_colours.contrast}})
                     if G.aij_astral_pin_area then
                         for _, v in pairs(G.aij_astral_pin_area.cards) do
                             v:remove()
@@ -2366,7 +2361,7 @@ function All_in_Jest.astral_visuals(hand, extra, old_colours, immediate, colours
                     return true
             end}))
         else
-            All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour}})
+            All_in_Jest.astral_background(nil, {background = {old_colours.special_colour, old_colours.tertiary_colour, old_colours.new_colour, old_colours.contrast}})
             if G.aij_astral_pin_area then
                 for _, v in pairs(G.aij_astral_pin_area.cards) do
                     v:remove()

--- a/Utils/hooks.lua
+++ b/Utils/hooks.lua
@@ -964,6 +964,25 @@ All_in_Jest.Astral = SMODS.Tag:extend {
     end
 }
 
+local aij_ease_bg_blind_ref = ease_background_colour_blind
+function ease_background_colour_blind(state, blind_override)
+    All_in_Jest.old_colours = nil
+    aij_ease_bg_blind_ref(state, blind_override)
+end
+
+local aij_ease_bg_ref = ease_background_colour
+function ease_background_colour(args)
+    if All_in_Jest.old_colours == nil then
+        All_in_Jest.old_colours = {
+            special_colour = copy_table(args['special_colour']),
+            tertiary_colour = copy_table(args['tertiary_colour']),
+            new_colour = copy_table(args['new_colour']),
+            contrast = args.contrast or 1,
+        }
+    end
+    aij_ease_bg_ref(args)
+end
+
 local init_game_object_ref = Game.init_game_object
 function Game.init_game_object(self)
   local ret = init_game_object_ref(self)

--- a/lovely/lovely.toml
+++ b/lovely/lovely.toml
@@ -4139,11 +4139,6 @@ update_hand_text({immediate = true, nopulse = nil, delay = 0}, {handname=disp_te
 payload = '''
 if G.GAME.Astral_pins then
     if text ~= G.aij_cur_astral_hand then
-        All_in_Jest.old_colours = All_in_Jest.old_colours or {
-            special_colour = copy_table(G.C.BACKGROUND.C),
-            tertiary_colour = copy_table(G.C.BACKGROUND.D),
-            new_colour = copy_table(G.C.BACKGROUND.L),
-        }
         All_in_Jest.astral_visuals(text, 'no_remove')
     end
     if text then
@@ -4180,6 +4175,9 @@ local text,disp_text,poker_hands = G.FUNCS.get_poker_hand_info(self.highlighted)
 payload = '''
 if G.GAME.Astral_pins and text ~= G.aij_cur_astral_hand then
     All_in_Jest.astral_visuals(text, 'only_remove', All_in_Jest.old_colours or nil, true)      
+    if text == "NULL" then
+        G.aij_cur_astral_hand = nil
+    end
     if G.aij_astral_pin_area then
         for _, v in pairs(G.aij_astral_pin_area.cards) do
             v:remove()
@@ -5148,7 +5146,9 @@ pattern = '-- TARGET: main end_of_round evaluation'
 position = 'after'
 match_indent = true
 payload = '''
-SMODS.destroy_cards(G.aij_astral_pin_area.cards, true)
+for _, v in ipairs(G.aij_astral_pin_area.cards) do
+    v:start_dissolve()
+end
 '''
 
 # evaluate_play()
@@ -5160,13 +5160,29 @@ pattern = '-- TARGET: effects after hand evaluation'
 position = 'after'
 match_indent = true
 payload = '''
-local pins_to_destroy = {}
 for _, v in ipairs(G.aij_astral_pin_area.cards) do
     if not v.ability.no_auto_destroy then
-        table.insert(pins_to_destroy, v)
+        v:start_dissolve()
     end
 end
-SMODS.destroy_cards(pins_to_destroy, true)
+'''
+
+# discard_cards_from_highlighted
+# Force astral pins to dissolve when discarding
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+pattern = '-- TARGET: pre_discard'
+position = 'after'
+match_indent = true
+payload = '''
+All_in_Jest.astral_visuals(text, 'only_remove', All_in_Jest.old_colours or nil, true)      
+G.aij_cur_astral_hand = nil
+if G.aij_astral_pin_area then
+    for _, v in ipairs(G.aij_astral_pin_area.cards) do
+        v:start_dissolve()
+    end
+end
 '''
 
 # This is so astral pins info queue can work


### PR DESCRIPTION
- replace all instances of using `SMODS.destroy_cards` on astral pins, as it crashes on the dev version of SMODS (the replaced code works identically to how it worked before)
- only define `All_in_Jest.old_colours` when the background color is being assigned to normally, rather than redefining it each time it changes (which can result in the color being incorrect)
- also define contrast in `old_colours` (previously resulted in inaccurate boss blind colors)
- fix right-clicking not properly removing the current astral hand
- fix discarding not getting rid of astral visuals